### PR TITLE
fix: compiled library should not have '64' appended

### DIFF
--- a/ittapi-rs/build.rs
+++ b/ittapi-rs/build.rs
@@ -19,7 +19,7 @@ fn main() {
             .build();
 
         println!("cargo:rustc-link-search={}/build/bin/", out_path.display());
-        println!("cargo:rustc-link-lib=static=ittnotify64");
+        println!("cargo:rustc-link-lib=static=ittnotify");
     }
 
     #[cfg(feature = "force_32")]


### PR DESCRIPTION
@jlb6740, this is what I had to do to get this to build on Fedora 31 (kernel: 5.8.8-100.fc31.x86_6), . What do you think?