### PR TITLE
Remove C style nullification

### DIFF
--- a/src/ittnotify/ittnotify_static.c
+++ b/src/ittnotify/ittnotify_static.c
@@ -280,7 +280,7 @@ __itt_global _N_(_ittapi_global) = {
 typedef void (__itt_api_init_t)(__itt_global*, __itt_group_id);
 typedef void (__itt_api_fini_t)(__itt_global*);
 
-static __itt_domain dummy_domain = {0};
+static __itt_domain dummy_domain;
 /* ========================================================================= */
 
 #ifdef ITT_NOTIFY_EXT_REPORT


### PR DESCRIPTION
`={0}` has slightly different semantics with C and C++. In this particular case, we can rely on zero initialization of objects with static storage duration.