### PR TITLE
Only use #pragma warning on MSVC on Windows

### DIFF
--- a/src/ittnotify/disable_warnings.h
+++ b/src/ittnotify/disable_warnings.h
@@ -8,11 +8,15 @@
 
 #if ITT_PLATFORM==ITT_PLATFORM_WIN
 
+#if defined _MSC_VER
+
 #pragma warning (disable: 593)   /* parameter "XXXX" was set but never used                 */
 #pragma warning (disable: 344)   /* typedef name has already been declared (with same type) */
 #pragma warning (disable: 174)   /* expression has no effect                                */
 #pragma warning (disable: 4127)  /* conditional expression is constant                      */
 #pragma warning (disable: 4306)  /* conversion from '?' to '?' of greater size              */
+
+#endif
 
 #endif /* ITT_PLATFORM==ITT_PLATFORM_WIN */
 


### PR DESCRIPTION
This matches other such ifdefs added in f42078d6.

This silences warnings when built in MinGW mode (as part of
the OpenMP runtime).