### PR TITLE
Fix ITT API initialization issue

### DIFF
--- a/src/ittnotify/ittnotify_static.c
+++ b/src/ittnotify/ittnotify_static.c
@@ -1261,7 +1261,7 @@ static int __itt_is_collector_available(void)
         __itt_mutex_unlock(&_N_(_ittapi_global).mutex);
         return _N_(_ittapi_global).state == __itt_collection_init_successful;
     }
-    if (NULL == __itt_get_lib_name())
+    if (_N_(_ittapi_global).state != __itt_collection_collector_exists && NULL == __itt_get_lib_name())
     {
         _N_(_ittapi_global).state = __itt_collection_collector_absent;
         __itt_mutex_unlock(&_N_(_ittapi_global).mutex);


### PR DESCRIPTION
__itt_get_lib_name() is called each time when ITT API instance is created. Environment variable
(for example, path to itt-library) is stored in static buffer and can be accessed by pointer.
The next environment variable will be stored to this buffer by offset not to overlap previous one.
Creating of many ITT API instances can lead to error report through __itt_report_error()
and/or absence of ITT API data.

So, check ITT collector existance before calling __itt_get_lib_name().