### PR TITLE
Improve README, publish README to crates.io

### DIFF
--- a/ittapi-rs/Cargo.toml
+++ b/ittapi-rs/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2018"
 description = "Rust bindings for ittapi"
 license-file = "LICENSES/"
 documentation  = "https://docs.rs/ittapi-rs"
+readme = "README.md"
 homepage  = "https://github.com/intel/ittapi/ittapi-rs"
 repository = "https://github.com/intel/ittapi"
+keywords = ["vtune", "profiling", "code-generation"]
 
 [dependencies]
 
@@ -18,5 +20,5 @@ force_32 = []
 cmake = "0.1.42"
 
 [dev-dependencies]
-bindgen = "0.52.0"
+bindgen = "0.59"
 diff = "0.1"

--- a/ittapi-rs/README.md
+++ b/ittapi-rs/README.md
@@ -1,14 +1,66 @@
 # ittapi-rs
-This package creates Rust bindings for ittapi. Ittapi is used for instrumentation and tracking and just-in-time profiling.
 
-Note the building of this package is currently only supported (tested) on a couple of Linux platforms (recent Ubuntu and Fedora builds) but support for other platforms is intended and contributions are welcomed.
+This package contains Rust bindings for the `ittapi` library--it is equivalent to a crate using [the
+`*-sys` convention][convention] but named differently for historical reasons. The `ittapi` library
+is used for various aspects of Intel&reg; profiling; it exposes the Instrumentation and Tracing
+Technology (ITT) API as well as the Just-In-Time (JIT) Profiling API. More details about `ittapi`
+are available on its [README].
 
-# Build the package
+[README]: https://github.com/intel/ittapi#readme
+[convention]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#-sys-packages
+
+> IMPORTANT NOTE: this package is currently only tested on several Linux platforms (recent Ubuntu
+> and Fedora builds) but support for other platforms is intended; contributions are welcome!
+
+If you are interested in using VTune to profile Rust applications, you may find the following guide
+helpful: [Wasmtime Docs: Using VTune on
+Linux](https://docs.wasmtime.dev/examples-profiling-vtune.html)
+
+
+### Use
+
+```toml
+[dependencies]
+ittapi = "0.1"
+```
+
+This crate currently uses the parent project's CMake configuration so a local CMake installation (as
+well as a C compiler) is necessary.
+
+
+### Build
+
+```
 cargo build
+```
 
-** Note This package uses bindgen which in turn requires recent versions of cmake and llvm to be installed. For Fedora, "yum install llvm-devel" was needed to bring in llvm-config.
+Building `ittapi-rs` will use CMake to build the `ittapi` library and link it statically into your
+application; see the [build.rs] file.
 
-** Also note building this package requires rust nightly.
+[build.rs]: https://github.com/intel/ittapi/blob/master/ittapi-rs/build.rs
 
-# Publish the package to crates.io
-cargo publish
+
+### Test
+
+```sh
+cargo test
+```
+
+This crate's tests ensure the `ittapi-rs` bindings remain up to date with the [official C header
+files]; they do not check `ittapi` functionality.
+
+[official C header files]: https://github.com/intel/ittapi/tree/master/include
+
+
+### Regenerate Bindings
+
+If the `ittapi-rs` bindings are not up to date, they can be regenerated with:
+
+```sh
+BLESS=1 cargo test
+```
+
+The binding generation uses `bindgen`. An in-depth description of how to use `bindgen` is available
+in [the `bindgen` documentation][bindgen docs].
+
+[bindgen docs]: https://rust-lang.github.io/rust-bindgen/


### PR DESCRIPTION
This change updates the README with more up-to-date information,
expanding several sections, and adding some new ones. It also adds the
`readme` field to `Cargo.toml` so that this information will show up on
https://crates.io/crates/ittapi-rs. It also updates the bindgen
dependency.