### PR TITLE
Update the ittapi Rust bindings

### DIFF
--- a/ittapi-rs/src/ittnotify_bindings.rs
+++ b/ittapi-rs/src/ittnotify_bindings.rs
@@ -13,6 +13,7 @@ pub const ITT_PLATFORM: u32 = 2;
 pub const _STDINT_H: u32 = 1;
 pub const _FEATURES_H: u32 = 1;
 pub const _DEFAULT_SOURCE: u32 = 1;
+pub const __GLIBC_USE_ISOC2X: u32 = 0;
 pub const __USE_ISOC11: u32 = 1;
 pub const __USE_ISOC99: u32 = 1;
 pub const __USE_ISOC95: u32 = 1;
@@ -26,34 +27,42 @@ pub const __USE_POSIX199506: u32 = 1;
 pub const __USE_XOPEN2K: u32 = 1;
 pub const __USE_XOPEN2K8: u32 = 1;
 pub const _ATFILE_SOURCE: u32 = 1;
+pub const __WORDSIZE: u32 = 64;
+pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
+pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __TIMESIZE: u32 = 64;
 pub const __USE_MISC: u32 = 1;
 pub const __USE_ATFILE: u32 = 1;
 pub const __USE_FORTIFY_LEVEL: u32 = 0;
 pub const __GLIBC_USE_DEPRECATED_GETS: u32 = 0;
+pub const __GLIBC_USE_DEPRECATED_SCANF: u32 = 0;
 pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
-pub const __STDC_NO_THREADS__: u32 = 1;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 27;
+pub const __GLIBC_MINOR__: u32 = 34;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
-pub const __WORDSIZE: u32 = 64;
-pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
-pub const __SYSCALL_WORDSIZE: u32 = 64;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_BFP_EXT_C2X: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_EXT: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_FUNCS_EXT: u32 = 0;
+pub const __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_TYPES_EXT: u32 = 0;
 pub const _BITS_TYPES_H: u32 = 1;
 pub const _BITS_TYPESIZES_H: u32 = 1;
 pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
+pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
+pub const _BITS_TIME64_H: u32 = 1;
 pub const _BITS_WCHAR_H: u32 = 1;
 pub const _BITS_STDINT_INTN_H: u32 = 1;
 pub const _BITS_STDINT_UINTN_H: u32 = 1;
@@ -164,6 +173,14 @@ pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
 pub type __int64_t = ::std::os::raw::c_long;
 pub type __uint64_t = ::std::os::raw::c_ulong;
+pub type __int_least8_t = __int8_t;
+pub type __uint_least8_t = __uint8_t;
+pub type __int_least16_t = __int16_t;
+pub type __uint_least16_t = __uint16_t;
+pub type __int_least32_t = __int32_t;
+pub type __uint_least32_t = __uint32_t;
+pub type __int_least64_t = __int64_t;
+pub type __uint_least64_t = __uint64_t;
 pub type __quad_t = ::std::os::raw::c_long;
 pub type __u_quad_t = ::std::os::raw::c_ulong;
 pub type __intmax_t = ::std::os::raw::c_long;
@@ -213,6 +230,7 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -233,14 +251,14 @@ pub type __caddr_t = *mut ::std::os::raw::c_char;
 pub type __intptr_t = ::std::os::raw::c_long;
 pub type __socklen_t = ::std::os::raw::c_uint;
 pub type __sig_atomic_t = ::std::os::raw::c_int;
-pub type int_least8_t = ::std::os::raw::c_schar;
-pub type int_least16_t = ::std::os::raw::c_short;
-pub type int_least32_t = ::std::os::raw::c_int;
-pub type int_least64_t = ::std::os::raw::c_long;
-pub type uint_least8_t = ::std::os::raw::c_uchar;
-pub type uint_least16_t = ::std::os::raw::c_ushort;
-pub type uint_least32_t = ::std::os::raw::c_uint;
-pub type uint_least64_t = ::std::os::raw::c_ulong;
+pub type int_least8_t = __int_least8_t;
+pub type int_least16_t = __int_least16_t;
+pub type int_least32_t = __int_least32_t;
+pub type int_least64_t = __int_least64_t;
+pub type uint_least8_t = __uint_least8_t;
+pub type uint_least16_t = __uint_least16_t;
+pub type uint_least32_t = __uint_least32_t;
+pub type uint_least64_t = __uint_least64_t;
 pub type int_fast8_t = ::std::os::raw::c_schar;
 pub type int_fast16_t = ::std::os::raw::c_long;
 pub type int_fast32_t = ::std::os::raw::c_long;
@@ -360,7 +378,17 @@ pub const __itt_suppress_mode___itt_suppress_range: __itt_suppress_mode = 1;
 #[doc = " @enum __itt_model_disable"]
 #[doc = " @brief Enumerator for the disable methods"]
 pub type __itt_suppress_mode = u32;
+#[doc = " @enum __itt_model_disable"]
+#[doc = " @brief Enumerator for the disable methods"]
 pub use self::__itt_suppress_mode as __itt_suppress_mode_t;
+pub const __itt_collection_state___itt_collection_uninitialized: __itt_collection_state = 0;
+pub const __itt_collection_state___itt_collection_init_fail: __itt_collection_state = 1;
+pub const __itt_collection_state___itt_collection_collector_absent: __itt_collection_state = 2;
+pub const __itt_collection_state___itt_collection_collector_exists: __itt_collection_state = 3;
+pub const __itt_collection_state___itt_collection_init_successful: __itt_collection_state = 4;
+#[doc = " @enum __itt_collection_state"]
+#[doc = " @brief Enumerator for collection state. All non-work states have negative values."]
+pub type __itt_collection_state = u32;
 extern "C" {
     #[doc = " @brief Mark a range of memory for error suppression or unsuppression for error types included in mask"]
     pub fn __itt_suppress_mark_range(
@@ -904,7 +932,7 @@ extern "C" {
     pub static mut __itt_heap_allocate_end_ptr__3_0: __itt_heap_allocate_end_ptr__3_0_t;
 }
 extern "C" {
-    #[doc = " @brief Record an free begin occurrence."]
+    #[doc = " @brief Record a free begin occurrence."]
     pub fn __itt_heap_free_begin(h: __itt_heap_function, addr: *mut ::std::os::raw::c_void);
 }
 pub type __itt_heap_free_begin_ptr__3_0_t = ::std::option::Option<
@@ -914,7 +942,7 @@ extern "C" {
     pub static mut __itt_heap_free_begin_ptr__3_0: __itt_heap_free_begin_ptr__3_0_t;
 }
 extern "C" {
-    #[doc = " @brief Record an free end occurrence."]
+    #[doc = " @brief Record a free end occurrence."]
     pub fn __itt_heap_free_end(h: __itt_heap_function, addr: *mut ::std::os::raw::c_void);
 }
 pub type __itt_heap_free_end_ptr__3_0_t = ::std::option::Option<
@@ -924,7 +952,7 @@ extern "C" {
     pub static mut __itt_heap_free_end_ptr__3_0: __itt_heap_free_end_ptr__3_0_t;
 }
 extern "C" {
-    #[doc = " @brief Record an reallocation begin occurrence."]
+    #[doc = " @brief Record a reallocation begin occurrence."]
     pub fn __itt_heap_reallocate_begin(
         h: __itt_heap_function,
         addr: *mut ::std::os::raw::c_void,
@@ -944,7 +972,7 @@ extern "C" {
     pub static mut __itt_heap_reallocate_begin_ptr__3_0: __itt_heap_reallocate_begin_ptr__3_0_t;
 }
 extern "C" {
-    #[doc = " @brief Record an reallocation end occurrence."]
+    #[doc = " @brief Record a reallocation end occurrence."]
     pub fn __itt_heap_reallocate_end(
         h: __itt_heap_function,
         addr: *mut ::std::os::raw::c_void,
@@ -2380,6 +2408,7 @@ extern "C" {
 pub const ___itt_track_group_type___itt_track_group_type_normal: ___itt_track_group_type = 0;
 #[doc = " @cond exclude_from_documentation"]
 pub type ___itt_track_group_type = u32;
+#[doc = " @cond exclude_from_documentation"]
 pub use self::___itt_track_group_type as __itt_track_group_type;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2474,6 +2503,8 @@ pub const ___itt_track_type___itt_track_type_normal: ___itt_track_type = 0;
 #[doc = " @brief Placeholder for custom track types. Currently, \"normal\" custom track"]
 #[doc = " is the only available track type."]
 pub type ___itt_track_type = u32;
+#[doc = " @brief Placeholder for custom track types. Currently, \"normal\" custom track"]
+#[doc = " is the only available track type."]
 pub use self::___itt_track_type as __itt_track_type;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -2984,4 +3015,164 @@ pub type __itt_module_unload_with_sections_ptr__3_0_t =
 extern "C" {
     pub static mut __itt_module_unload_with_sections_ptr__3_0:
         __itt_module_unload_with_sections_ptr__3_0_t;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct ___itt_histogram {
+    #[doc = "< Domain of the histogram"]
+    pub domain: *const __itt_domain,
+    #[doc = "< Name of the histogram"]
+    pub nameA: *const ::std::os::raw::c_char,
+    pub nameW: *mut ::std::os::raw::c_void,
+    #[doc = "< Type of the histogram X axis"]
+    pub x_type: __itt_metadata_type,
+    #[doc = "< Type of the histogram Y axis"]
+    pub y_type: __itt_metadata_type,
+    #[doc = "< Reserved to the runtime"]
+    pub extra1: ::std::os::raw::c_int,
+    #[doc = "< Reserved to the runtime"]
+    pub extra2: *mut ::std::os::raw::c_void,
+    pub next: *mut ___itt_histogram,
+}
+#[test]
+fn bindgen_test_layout____itt_histogram() {
+    assert_eq!(
+        ::std::mem::size_of::<___itt_histogram>(),
+        56usize,
+        concat!("Size of: ", stringify!(___itt_histogram))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<___itt_histogram>(),
+        8usize,
+        concat!("Alignment of ", stringify!(___itt_histogram))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<___itt_histogram>())).domain as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(___itt_histogram),
+            "::",
+            stringify!(domain)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<___itt_histogram>())).nameA as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(___itt_histogram),
+            "::",
+            stringify!(nameA)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<___itt_histogram>())).nameW as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(___itt_histogram),
+            "::",
+            stringify!(nameW)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<___itt_histogram>())).x_type as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(___itt_histogram),
+            "::",
+            stringify!(x_type)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<___itt_histogram>())).y_type as *const _ as usize },
+        28usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(___itt_histogram),
+            "::",
+            stringify!(y_type)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<___itt_histogram>())).extra1 as *const _ as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(___itt_histogram),
+            "::",
+            stringify!(extra1)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<___itt_histogram>())).extra2 as *const _ as usize },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(___itt_histogram),
+            "::",
+            stringify!(extra2)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<___itt_histogram>())).next as *const _ as usize },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(___itt_histogram),
+            "::",
+            stringify!(next)
+        )
+    );
+}
+pub type __itt_histogram = ___itt_histogram;
+extern "C" {
+    pub fn __itt_histogram_create(
+        domain: *const __itt_domain,
+        name: *const ::std::os::raw::c_char,
+        x_type: __itt_metadata_type,
+        y_type: __itt_metadata_type,
+    ) -> *mut __itt_histogram;
+}
+pub type __itt_histogram_create_ptr__3_0_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        domain: *const __itt_domain,
+        name: *const ::std::os::raw::c_char,
+        x_type: __itt_metadata_type,
+        y_type: __itt_metadata_type,
+    ) -> *mut __itt_histogram,
+>;
+extern "C" {
+    pub static mut __itt_histogram_create_ptr__3_0: __itt_histogram_create_ptr__3_0_t;
+}
+extern "C" {
+    #[doc = " @brief Submit statistics for a histogram instance."]
+    #[doc = " @param[in] hist    Pointer to the histogram instance to which the histogram statistic is to be dumped."]
+    #[doc = " @param[in] length  The number of elements in dumped axis data array."]
+    #[doc = " @param[in] x_data  The X axis dumped data itself (may be NULL to calculate batch statistics)."]
+    #[doc = " @param[in] y_data  The Y axis dumped data itself."]
+    pub fn __itt_histogram_submit(
+        hist: *mut __itt_histogram,
+        length: usize,
+        x_data: *mut ::std::os::raw::c_void,
+        y_data: *mut ::std::os::raw::c_void,
+    );
+}
+pub type __itt_histogram_submit_ptr__3_0_t = ::std::option::Option<
+    unsafe extern "C" fn(
+        hist: *mut __itt_histogram,
+        length: usize,
+        x_data: *mut ::std::os::raw::c_void,
+        y_data: *mut ::std::os::raw::c_void,
+    ),
+>;
+extern "C" {
+    pub static mut __itt_histogram_submit_ptr__3_0: __itt_histogram_submit_ptr__3_0_t;
+}
+extern "C" {
+    #[doc = " @brief function allows to obtain the current collection state at the moment"]
+    #[doc = " @return collection state as a enum __itt_collection_state"]
+    pub fn __itt_get_collection_state() -> __itt_collection_state;
 }

--- a/ittapi-rs/src/jitprofiling_bindings.rs
+++ b/ittapi-rs/src/jitprofiling_bindings.rs
@@ -50,6 +50,7 @@ pub const iJIT_jvm_event_iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED_V2: iJIT_jvm_event
 pub const iJIT_jvm_event_iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED_V3: iJIT_jvm_event = 22;
 #[doc = " @brief Enumerator for the types of notifications"]
 pub type iJIT_jvm_event = u32;
+#[doc = " @brief Enumerator for the types of notifications"]
 pub use self::iJIT_jvm_event as iJIT_JVM_EVENT;
 #[doc = "<\\brief The agent is not running;"]
 #[doc = " iJIT_NotifyEvent calls will"]
@@ -60,6 +61,7 @@ pub const _iJIT_IsProfilingActiveFlags_iJIT_NOTHING_RUNNING: _iJIT_IsProfilingAc
 pub const _iJIT_IsProfilingActiveFlags_iJIT_SAMPLING_ON: _iJIT_IsProfilingActiveFlags = 1;
 #[doc = " @brief Enumerator for the agent's mode"]
 pub type _iJIT_IsProfilingActiveFlags = u32;
+#[doc = " @brief Enumerator for the agent's mode"]
 pub use self::_iJIT_IsProfilingActiveFlags as iJIT_IsProfilingActiveFlags;
 #[doc = " @brief Description of a single entry in the line number information of a code region."]
 #[doc = " @details A table of line number entries gives information about how the reported code region"]
@@ -125,7 +127,53 @@ fn bindgen_test_layout__LineNumberInfo() {
         )
     );
 }
+#[doc = " @brief Description of a single entry in the line number information of a code region."]
+#[doc = " @details A table of line number entries gives information about how the reported code region"]
+#[doc = " is mapped to source file."]
+#[doc = " Intel(R) VTune(TM) Amplifier uses line number information to attribute"]
+#[doc = " the samples (virtual address) to a line number. \\n"]
+#[doc = " It is acceptable to report different code addresses for the same source line:"]
+#[doc = " @code"]
+#[doc = "   Offset LineNumber"]
+#[doc = "      1       2"]
+#[doc = "      12      4"]
+#[doc = "      15      2"]
+#[doc = "      18      1"]
+#[doc = "      21      30"]
+#[doc = ""]
+#[doc = "  VTune Amplifier constructs the following table using the client data"]
+#[doc = ""]
+#[doc = "   Code subrange  Line number"]
+#[doc = "      0-1             2"]
+#[doc = "      1-12            4"]
+#[doc = "      12-15           2"]
+#[doc = "      15-18           1"]
+#[doc = "      18-21           30"]
+#[doc = " @endcode"]
 pub type pLineNumberInfo = *mut _LineNumberInfo;
+#[doc = " @brief Description of a single entry in the line number information of a code region."]
+#[doc = " @details A table of line number entries gives information about how the reported code region"]
+#[doc = " is mapped to source file."]
+#[doc = " Intel(R) VTune(TM) Amplifier uses line number information to attribute"]
+#[doc = " the samples (virtual address) to a line number. \\n"]
+#[doc = " It is acceptable to report different code addresses for the same source line:"]
+#[doc = " @code"]
+#[doc = "   Offset LineNumber"]
+#[doc = "      1       2"]
+#[doc = "      12      4"]
+#[doc = "      15      2"]
+#[doc = "      18      1"]
+#[doc = "      21      30"]
+#[doc = ""]
+#[doc = "  VTune Amplifier constructs the following table using the client data"]
+#[doc = ""]
+#[doc = "   Code subrange  Line number"]
+#[doc = "      0-1             2"]
+#[doc = "      1-12            4"]
+#[doc = "      12-15           2"]
+#[doc = "      15-18           1"]
+#[doc = "      18-21           30"]
+#[doc = " @endcode"]
 pub type LineNumberInfo = _LineNumberInfo;
 #[doc = "<\\brief Native to the process architecture that is calling it."]
 pub const _iJIT_CodeArchitecture_iJIT_CA_NATIVE: _iJIT_CodeArchitecture = 0;
@@ -135,6 +183,7 @@ pub const _iJIT_CodeArchitecture_iJIT_CA_32: _iJIT_CodeArchitecture = 1;
 pub const _iJIT_CodeArchitecture_iJIT_CA_64: _iJIT_CodeArchitecture = 2;
 #[doc = " @brief Enumerator for the code architecture."]
 pub type _iJIT_CodeArchitecture = u32;
+#[doc = " @brief Enumerator for the code architecture."]
 pub use self::_iJIT_CodeArchitecture as iJIT_CodeArchitecture;
 #[doc = " @brief Description of a JIT-compiled method"]
 #[doc = " @details When you use the iJIT_Method_Load structure to describe"]
@@ -294,7 +343,15 @@ fn bindgen_test_layout__iJIT_Method_Load() {
         )
     );
 }
+#[doc = " @brief Description of a JIT-compiled method"]
+#[doc = " @details When you use the iJIT_Method_Load structure to describe"]
+#[doc = "  the JIT compiled method, use iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED"]
+#[doc = "  as an event type to report it."]
 pub type piJIT_Method_Load = *mut _iJIT_Method_Load;
+#[doc = " @brief Description of a JIT-compiled method"]
+#[doc = " @details When you use the iJIT_Method_Load structure to describe"]
+#[doc = "  the JIT compiled method, use iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED"]
+#[doc = "  as an event type to report it."]
 pub type iJIT_Method_Load = _iJIT_Method_Load;
 #[doc = " @brief Description of a JIT-compiled method"]
 #[doc = " @details When you use the iJIT_Method_Load_V2 structure to describe"]
@@ -464,7 +521,15 @@ fn bindgen_test_layout__iJIT_Method_Load_V2() {
         )
     );
 }
+#[doc = " @brief Description of a JIT-compiled method"]
+#[doc = " @details When you use the iJIT_Method_Load_V2 structure to describe"]
+#[doc = "  the JIT compiled method, use iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED_V2"]
+#[doc = "  as an event type to report it."]
 pub type piJIT_Method_Load_V2 = *mut _iJIT_Method_Load_V2;
+#[doc = " @brief Description of a JIT-compiled method"]
+#[doc = " @details When you use the iJIT_Method_Load_V2 structure to describe"]
+#[doc = "  the JIT compiled method, use iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED_V2"]
+#[doc = "  as an event type to report it."]
 pub type iJIT_Method_Load_V2 = _iJIT_Method_Load_V2;
 #[doc = " @brief Description of a JIT-compiled method"]
 #[doc = " @details The iJIT_Method_Load_V3 structure is the same as iJIT_Method_Load_V2"]
@@ -661,7 +726,19 @@ fn bindgen_test_layout__iJIT_Method_Load_V3() {
         )
     );
 }
+#[doc = " @brief Description of a JIT-compiled method"]
+#[doc = " @details The iJIT_Method_Load_V3 structure is the same as iJIT_Method_Load_V2"]
+#[doc = "  with a newly introduced 'arch' field that specifies architecture of the code region."]
+#[doc = "  When you use the iJIT_Method_Load_V3 structure to describe"]
+#[doc = "  the JIT compiled method, use iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED_V3"]
+#[doc = "  as an event type to report it."]
 pub type piJIT_Method_Load_V3 = *mut _iJIT_Method_Load_V3;
+#[doc = " @brief Description of a JIT-compiled method"]
+#[doc = " @details The iJIT_Method_Load_V3 structure is the same as iJIT_Method_Load_V2"]
+#[doc = "  with a newly introduced 'arch' field that specifies architecture of the code region."]
+#[doc = "  When you use the iJIT_Method_Load_V3 structure to describe"]
+#[doc = "  the JIT compiled method, use iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED_V3"]
+#[doc = "  as an event type to report it."]
 pub type iJIT_Method_Load_V3 = _iJIT_Method_Load_V3;
 #[doc = " @brief Description of an inline JIT-compiled method"]
 #[doc = " @details When you use the_iJIT_Method_Inline_Load structure to describe"]
@@ -834,7 +911,15 @@ fn bindgen_test_layout__iJIT_Method_Inline_Load() {
         )
     );
 }
+#[doc = " @brief Description of an inline JIT-compiled method"]
+#[doc = " @details When you use the_iJIT_Method_Inline_Load structure to describe"]
+#[doc = "  the JIT compiled method, use iJVM_EVENT_TYPE_METHOD_INLINE_LOAD_FINISHED"]
+#[doc = "  as an event type to report it."]
 pub type piJIT_Method_Inline_Load = *mut _iJIT_Method_Inline_Load;
+#[doc = " @brief Description of an inline JIT-compiled method"]
+#[doc = " @details When you use the_iJIT_Method_Inline_Load structure to describe"]
+#[doc = "  the JIT compiled method, use iJVM_EVENT_TYPE_METHOD_INLINE_LOAD_FINISHED"]
+#[doc = "  as an event type to report it."]
 pub type iJIT_Method_Inline_Load = _iJIT_Method_Inline_Load;
 pub const _iJIT_SegmentType_iJIT_CT_UNKNOWN: _iJIT_SegmentType = 0;
 #[doc = "<\\brief Executable code."]
@@ -857,6 +942,11 @@ pub const _iJIT_SegmentType_iJIT_CT_EOF: _iJIT_SegmentType = 4;
 #[doc = " with the iJVM_EVENT_TYPE_METHOD_UPDATE_V2 event to be applied to"]
 #[doc = " a certain code trace."]
 pub type _iJIT_SegmentType = u32;
+#[doc = " @cond exclude_from_documentation */"]
+#[doc = " @brief Description of a segment type"]
+#[doc = " @details Use the segment type to specify a type of data supplied"]
+#[doc = " with the iJVM_EVENT_TYPE_METHOD_UPDATE_V2 event to be applied to"]
+#[doc = " a certain code trace."]
 pub use self::_iJIT_SegmentType as iJIT_SegmentType;
 #[doc = " @brief Description of a dynamic update of the content within JIT-compiled method"]
 #[doc = " @details The JIT engine may generate the methods that are updated at runtime"]
@@ -963,7 +1053,75 @@ fn bindgen_test_layout__iJIT_Method_Update() {
         )
     );
 }
+#[doc = " @brief Description of a dynamic update of the content within JIT-compiled method"]
+#[doc = " @details The JIT engine may generate the methods that are updated at runtime"]
+#[doc = " partially by mixed (data + executable code) content. When you use the iJIT_Method_Update"]
+#[doc = " structure to describe the update of the content within a JIT-compiled method,"]
+#[doc = " use iJVM_EVENT_TYPE_METHOD_UPDATE_V2 as an event type to report it."]
+#[doc = ""]
+#[doc = " On the first Update event, VTune Amplifier copies the original code range reported by"]
+#[doc = " the iJVM_EVENT_TYPE_METHOD_LOAD event, then modifies it with the supplied bytes and"]
+#[doc = " adds the modified range to the original method. For next update events, VTune Amplifier"]
+#[doc = " does the same but it uses the latest modified version of a code region for update."]
+#[doc = " Eventually, VTune Amplifier GUI displays multiple code ranges for the method reported by"]
+#[doc = " the iJVM_EVENT_TYPE_METHOD_LOAD event."]
+#[doc = " Notes:"]
+#[doc = " - Multiple update events with different types for the same trace are allowed"]
+#[doc = "   but they must be reported for the same code ranges."]
+#[doc = "   Example,"]
+#[doc = " @code"]
+#[doc = "                      [-- data---]        Allowed"]
+#[doc = "          [-- code --]                    Allowed"]
+#[doc = "        [code]                            Ignored"]
+#[doc = "                      [-- data---]        Allowed"]
+#[doc = "          [-- code --]                    Allowed"]
+#[doc = "      [------------ trace ---------]"]
+#[doc = " @endcode"]
+#[doc = " - The types of previously reported events can be changed but they must be reported"]
+#[doc = "   for the same code ranges."]
+#[doc = "   Example,"]
+#[doc = " @code"]
+#[doc = "          [-- data---]                    Allowed"]
+#[doc = "          [-- code --]                    Allowed"]
+#[doc = "          [-- data---]                    Allowed"]
+#[doc = "          [-- code --]                    Allowed"]
+#[doc = "      [------------ trace ---------]"]
+#[doc = " @endcode"]
 pub type piJIT_Method_Update = *mut _iJIT_Method_Update;
+#[doc = " @brief Description of a dynamic update of the content within JIT-compiled method"]
+#[doc = " @details The JIT engine may generate the methods that are updated at runtime"]
+#[doc = " partially by mixed (data + executable code) content. When you use the iJIT_Method_Update"]
+#[doc = " structure to describe the update of the content within a JIT-compiled method,"]
+#[doc = " use iJVM_EVENT_TYPE_METHOD_UPDATE_V2 as an event type to report it."]
+#[doc = ""]
+#[doc = " On the first Update event, VTune Amplifier copies the original code range reported by"]
+#[doc = " the iJVM_EVENT_TYPE_METHOD_LOAD event, then modifies it with the supplied bytes and"]
+#[doc = " adds the modified range to the original method. For next update events, VTune Amplifier"]
+#[doc = " does the same but it uses the latest modified version of a code region for update."]
+#[doc = " Eventually, VTune Amplifier GUI displays multiple code ranges for the method reported by"]
+#[doc = " the iJVM_EVENT_TYPE_METHOD_LOAD event."]
+#[doc = " Notes:"]
+#[doc = " - Multiple update events with different types for the same trace are allowed"]
+#[doc = "   but they must be reported for the same code ranges."]
+#[doc = "   Example,"]
+#[doc = " @code"]
+#[doc = "                      [-- data---]        Allowed"]
+#[doc = "          [-- code --]                    Allowed"]
+#[doc = "        [code]                            Ignored"]
+#[doc = "                      [-- data---]        Allowed"]
+#[doc = "          [-- code --]                    Allowed"]
+#[doc = "      [------------ trace ---------]"]
+#[doc = " @endcode"]
+#[doc = " - The types of previously reported events can be changed but they must be reported"]
+#[doc = "   for the same code ranges."]
+#[doc = "   Example,"]
+#[doc = " @code"]
+#[doc = "          [-- data---]                    Allowed"]
+#[doc = "          [-- code --]                    Allowed"]
+#[doc = "          [-- data---]                    Allowed"]
+#[doc = "          [-- code --]                    Allowed"]
+#[doc = "      [------------ trace ---------]"]
+#[doc = " @endcode"]
 pub type iJIT_Method_Update = _iJIT_Method_Update;
 extern "C" {
     #[doc = " @brief Generates a new unique method ID."]


### PR DESCRIPTION
The `ittapi` bindings have changed slightly and this change regenerates
them from the latest header files.