### PR TITLE
Bump ittapi-rs version

### DIFF
--- a/ittapi-rs/Cargo.toml
+++ b/ittapi-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ittapi-rs"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Johnnie Birch <45402135+jlb6740@users.noreply.github.com>"]
 edition = "2018"
 description = "Rust bindings for ittapi"


### PR DESCRIPTION
This change allows us to publish the latest changes to crates.io.