### PR TITLE
ci: add initial GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  c_build:
+    name: Check C library
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build C library
+      run: python buildall.py
+
+  rust_format:
+    name: Check Rust formatting
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ittapi-rs
+    steps:
+    - uses: actions/checkout@v2
+    - run: rustup component add rustfmt
+    - run: cargo fmt --all -- --check
+
+  rust_build:
+    name: Check Rust crate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ittapi-rs
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build Rust crate
+      run: cargo build
+    - name: Test Rust crate
+      run: cargo test
+    - name: Check crate is publishable
+      run: cargo publish --dry-run


### PR DESCRIPTION
This change adds GitHub workflows to build both the C library and Rust
crate that depends on it. Though it does not check that VTune
collection works correctly with the built library, this change closes
 #17 in expectation that this level of testing will be added later (it
requires an environment with hardware and applications that may be more
easy to control elsewhere?).