### PR TITLE
rust: remove `32` and `64` postfix when in lib name

### DIFF
--- a/ittapi-rs/build.rs
+++ b/ittapi-rs/build.rs
@@ -16,7 +16,7 @@ fn main() {
             .file("src/ittnotify/jitprofiling.c")
             .include("src/ittnotify/")
             .include("include/")
-            .compile("ittnotify64");
+            .compile("ittnotify");
     }
 
     #[cfg(feature = "force_32")]
@@ -27,6 +27,6 @@ fn main() {
             .define("FORCE_32", "ON")
             .include("src/ittnotify/")
             .include("include/")
-            .compile("ittnotify32");
+            .compile("ittnotify");
     }
 }


### PR DESCRIPTION
As discussed in #32, change 8601f82 no longer sets a different name for
32- and 64-bit builds of the `ittapi` library. This change does the same
for the Rust build script.