### PR TITLE
Remove CMake documentation from Rust bindings

### DIFF
--- a/ittapi-rs/README.md
+++ b/ittapi-rs/README.md
@@ -24,9 +24,6 @@ Linux](https://docs.wasmtime.dev/examples-profiling-vtune.html)
 ittapi = "0.1"
 ```
 
-This crate currently uses the parent project's CMake configuration so a local CMake installation (as
-well as a C compiler) is necessary.
-
 
 ### Build
 
@@ -34,8 +31,8 @@ well as a C compiler) is necessary.
 cargo build
 ```
 
-Building `ittapi-rs` will use CMake to build the `ittapi` library and link it statically into your
-application; see the [build.rs] file.
+Building `ittapi-rs` will build the `ittapi` C library and link it statically into your application;
+see the [build.rs] file.
 
 [build.rs]: https://github.com/intel/ittapi/blob/master/ittapi-rs/build.rs
 

--- a/ittapi-rs/build.rs
+++ b/ittapi-rs/build.rs
@@ -1,3 +1,6 @@
+//! Build the `ittapi` C library in the parent directory. The `cc` configuration here should match
+//! that of the parent directories `CMakeLists.txt` (TODO: keep these in sync,
+//! https://github.com/intel/ittapi/issues/36).
 #![allow(unused)]
 use std::env;
 use std::path::PathBuf;
@@ -12,7 +15,8 @@ fn main() {
 
     #[cfg(not(feature = "force_32"))]
     {
-        cc::Build::new().file("src/ittnotify/ittnotify_static.c")
+        cc::Build::new()
+            .file("src/ittnotify/ittnotify_static.c")
             .file("src/ittnotify/jitprofiling.c")
             .include("src/ittnotify/")
             .include("include/")
@@ -22,7 +26,8 @@ fn main() {
     #[cfg(feature = "force_32")]
     #[cfg(not(any(target_os = "ios", target_os = "macos")))]
     {
-        cc::Build::new().file("src/ittnotify/ittnotify_static.c")
+        cc::Build::new()
+            .file("src/ittnotify/ittnotify_static.c")
             .file("src/ittnotify/jitprofiling.c")
             .define("FORCE_32", "ON")
             .include("src/ittnotify/")


### PR DESCRIPTION
Since #32, we no longer need to mention CMake as a dependency.