### PR TITLE
rust: add a workaround for developing the Rust crate on Windows

### DIFF
--- a/ittapi-rs/.gitignore
+++ b/ittapi-rs/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+c-library

--- a/ittapi-rs/README.md
+++ b/ittapi-rs/README.md
@@ -36,6 +36,13 @@ see the [build.rs] file.
 
 [build.rs]: https://github.com/intel/ittapi/blob/master/ittapi-rs/build.rs
 
+_For Windows developers_: this crate uses a symbolic link to access the C library it depends on. To
+modify this crate on Windows, either [configure Git to understand POSIX symlinks] or use the
+[copy-c-library.ps1] script to temporarily copy the files.
+
+[configure Git to understand POSIX symlinks]: https://github.com/git-for-windows/git/wiki/Symbolic-Links
+[copy-c-library.ps1]: scripts/copy-c-library.ps1
+
 
 ### Test
 

--- a/ittapi-rs/scripts/copy-c-library.ps1
+++ b/ittapi-rs/scripts/copy-c-library.ps1
@@ -1,0 +1,8 @@
+# Copy the source code of the C library into `ittapi-rs/c-library`. This is a workaround for Windows
+# developers that may not be able to use POSIX symlinks. Also see:
+# https://github.com/git-for-windows/git/wiki/Symbolic-Links.
+$cLibrary = $MyInvocation.MyCommand.Path | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent
+$rustLibrary = Join-Path -Path $cLibrary -ChildPath "ittapi-rs"
+$linkLocation = Join-Path -Path $rustLibrary -ChildPath "c-library"
+Remove-Item $linkLocation -Force -Recurse
+robocopy $cLibrary $linkLocation /e /xd ".git" "build" "ittapi-rs"


### PR DESCRIPTION
The Rust crate uses a POSIX symlink for accessing the C library files.
On Windows this may not work so we document two workarounds.