### PR TITLE
rust: bump version to v0.2.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,13 +51,6 @@ jobs:
         submodules: recursive
     - name: Build Rust crate
       run: cargo build
-    # On Windows, libclang.dll can be found in two places, including a mingw directory. As we're not
-    # using any of mingw tools in our case, we can hide it by removing the library. See also:
-    # https://github.com/actions/virtual-environments/issues/2208.
-    - name: Hide spurious mingw directory (Windows only)
-      shell: powershell
-      run: Remove-Item -Path C:\msys64\mingw64\bin\libclang.dll -Force
-      if: matrix.os == 'windows-latest'
     - name: Test Rust crate
       run: cargo test
     # For some strange reason, the process of building the upstream library will result in source

--- a/ittapi-rs/CHANGELOG.md
+++ b/ittapi-rs/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [0.2.0] - 2022-02-16
+### Added
+- Windows support; the crate now contains bindings for Windows, Linux, and macOS
+### Removed
+- The `force32` feature; 32-bit binaries are unsupported until someone requests to re-add this
+
+## [0.1.6] - 2021-12-17
+### Changed
+- Fixed the license string in `Cargo.toml`
+- Improved documentation

--- a/ittapi-rs/Cargo.toml
+++ b/ittapi-rs/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 homepage  = "https://github.com/intel/ittapi/ittapi-rs"
 repository = "https://github.com/intel/ittapi"
 keywords = ["vtune", "profiling", "code-generation"]
+exclude = ["c-library/.*"]
 
 [dependencies]
 

--- a/ittapi-rs/Cargo.toml
+++ b/ittapi-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ittapi-rs"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["Johnnie Birch <45402135+jlb6740@users.noreply.github.com>"]
 edition = "2018"
 description = "Rust bindings for ittapi"


### PR DESCRIPTION
Recent changes to enable Windows support have slightly altered the
bindings, which changes the public API. These are not breaking changes
but a minor version bump seems appropriate, especially with the new OS
support.