### PR TITLE
rust: add more APIs to the new high-level `ittapi` crate

### DIFF
--- a/ittapi-rs/integration-tests/Cargo.toml
+++ b/ittapi-rs/integration-tests/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ittapi-integration-test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+ittapi = { path = "../ittapi" }
+
+[workspace]
+# Do not include this crate in the workspace.

--- a/ittapi-rs/integration-tests/README.md
+++ b/ittapi-rs/integration-tests/README.md
@@ -1,0 +1,17 @@
+# ittapi Integration Tests
+
+This crate checks the functionality of the high-level `ittapi` crate using a VTune installation on
+the current system. It exists solely for testing in a specially configured environment and will not
+be published.
+
+### Test
+
+On a system with VTune installed:
+
+```
+source vtune-vars.sh
+cargo test
+```
+
+To install VTune, see the [User
+Guide](https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/installation.html).

--- a/ittapi-rs/integration-tests/README.md
+++ b/ittapi-rs/integration-tests/README.md
@@ -15,3 +15,6 @@ cargo test
 
 To install VTune, see the [User
 Guide](https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/installation.html).
+The environment setup script (e.g., `vtune-vars.sh`) can be found within the VTune installation;
+e.g., `$HOME/intel/oneapi/vtune/latest` or `/opt/intel/oneapi/vtune/latest` on
+[Linux](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-vtune/top/linux-os.html).

--- a/ittapi-rs/integration-tests/src/main.rs
+++ b/ittapi-rs/integration-tests/src/main.rs
@@ -1,0 +1,17 @@
+use ittapi::{Domain, Task};
+use std::{thread::sleep, time::Duration};
+
+fn main() {
+    let task_duration = Duration::from_millis(50);
+    let domain = Domain::new("test");
+
+    let task1 = Task::begin(&domain, "task#1");
+    println!("Running task#1...");
+    sleep(task_duration);
+    task1.end();
+
+    let task2 = Task::begin(&domain, "task#2");
+    println!("Running task#2...");
+    sleep(task_duration);
+    task2.end()
+}

--- a/ittapi-rs/integration-tests/tests/main.rs
+++ b/ittapi-rs/integration-tests/tests/main.rs
@@ -1,0 +1,68 @@
+//! To check that the high-level Rust API works, we perform two kinds of checks here:
+//!  1. `run_without_collector`: run the test binary and check that the ITT calls do not break
+//!     anything.
+//!  2. `run_with_collector`: run the test binary in VTune and check that the created report has
+//!     captured the tasks; this relies on having VTune installed and configured (e.g., `vtune`
+//!     binary available on the PATH, like done with `source vtune-vars.sh`).
+use std::fs::remove_dir_all;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::str::from_utf8;
+
+#[test]
+fn run_without_collector() {
+    let stdout = run(&["cargo", "run"]);
+    assert!(stdout.contains("Running task#1..."));
+    assert!(stdout.contains("Running task#2..."));
+}
+
+#[test]
+fn run_with_collector() {
+    // First, clean up any previously created results.
+    const RESULT_DIR: &str = "target/vtune-results";
+    if Path::new(RESULT_DIR).exists() {
+        remove_dir_all(RESULT_DIR).unwrap();
+    }
+
+    // Then, collect the results using VTune.
+    let result_dir_flag = &format!("-result-dir={}", RESULT_DIR);
+    let collect_stdout = run(&[
+        "vtune",
+        "-collect",
+        "hotspots",
+        result_dir_flag,
+        "-knob",
+        "sampling-mode=hw",
+        "cargo",
+        "run",
+    ]);
+    assert!(collect_stdout.contains("Running task#1..."));
+    assert!(collect_stdout.contains("Running task#2..."));
+
+    // Finally, check that the created report actually contains the measured tasks. It may be
+    // interesting to filter by task here: e.g.,
+    // https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/command-line-interface/generating-command-line-reports/filtering-and-grouping-reports.html.
+    let report_stdout = run(&["vtune", "-report", "summary", result_dir_flag]);
+    assert!(report_stdout.contains("task#1 "));
+    assert!(report_stdout.contains("task#2 "));
+}
+
+/// Helper for executing system commands, returning the stdout.
+fn run(command: &[&str]) -> String {
+    let output = Command::new(command[0])
+        .args(&command[1..])
+        .output()
+        .expect("failed to execute process");
+
+    let stdout = from_utf8(&output.stdout).unwrap();
+    eprintln!("=== stdout ===\n{}\n==============", stdout);
+    let stderr = from_utf8(&output.stderr).unwrap();
+    eprintln!("=== stderr ===\n{}\n==============", stderr);
+
+    assert!(
+        output.status.success(),
+        "failed to run command: `{}`",
+        command.join(" ")
+    );
+    stdout.to_string()
+}

--- a/ittapi-rs/ittapi-sys/README.md
+++ b/ittapi-rs/ittapi-sys/README.md
@@ -1,15 +1,17 @@
-# ittapi-rs
+# ittapi-sys
 
-This package contains Rust bindings for the `ittapi` library--it is equivalent to a crate using [the
-`*-sys` convention][convention] but named differently for historical reasons. The `ittapi` library
-is used for various aspects of Intel&reg; profiling; it exposes the Instrumentation and Tracing
-Technology (ITT) API as well as the Just-In-Time (JIT) Profiling API. More details about `ittapi`
-are available on its [README].
+[![Build Status](https://github.com/intel/ittapi/workflows/CI/badge.svg)][ci]
+[![Documentation Status](https://docs.rs/ittapi-sys/badge.svg)][docs]
 
+This crate contains low-level Rust bindings for the C `ittapi` library--you likely want to use the
+[high-level Rust crate]. The `ittapi` library is used for various aspects of Intel&reg; profiling;
+it exposes the Instrumentation and Tracing Technology (ITT) API as well as the Just-In-Time (JIT)
+Profiling API. More details about `ittapi` are available on its [README].
+
+[high-level Rust crate]: https://github.com/intel/ittapi/ittapi-rs/ittapi
 [README]: https://github.com/intel/ittapi#readme
-[convention]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#-sys-packages
 
-> IMPORTANT NOTE: this package is currently only tested on Linux, macOS, and Windows platforms but
+> IMPORTANT NOTE: this crate is currently only tested on Linux, macOS, and Windows platforms but
 > support for other platforms is intended; contributions are welcome!
 
 If you are interested in using VTune to profile Rust applications, you may find the following guide
@@ -21,7 +23,7 @@ Linux](https://docs.wasmtime.dev/examples-profiling-vtune.html)
 
 ```toml
 [dependencies]
-ittapi = "0.1"
+ittapi-sys = "0.2"
 ```
 
 
@@ -31,8 +33,8 @@ ittapi = "0.1"
 cargo build
 ```
 
-Building `ittapi-rs` will build the `ittapi` C library and link it statically into your application;
-see the [build.rs] file.
+Building `ittapi-sys` will build the `ittapi` C library and link it statically into your
+application; see the [build.rs] file.
 
 [build.rs]: https://github.com/intel/ittapi/blob/master/ittapi-rs/build.rs
 
@@ -50,7 +52,7 @@ modify this crate on Windows, either [configure Git to understand POSIX symlinks
 cargo test
 ```
 
-This crate's tests ensure the `ittapi-rs` bindings remain up to date with the [official C header
+This crate's tests ensure the `ittapi-sys` bindings remain up to date with the [official C header
 files]; they do not check `ittapi` functionality.
 
 [official C header files]: https://github.com/intel/ittapi/tree/master/include
@@ -58,7 +60,7 @@ files]; they do not check `ittapi` functionality.
 
 ### Regenerate Bindings
 
-If the `ittapi-rs` bindings are not up to date, they can be regenerated with:
+If the `ittapi-sys` bindings are not up to date, they can be regenerated with:
 
 ```sh
 BLESS=1 cargo test

--- a/ittapi-rs/ittapi-sys/src/lib.rs
+++ b/ittapi-rs/ittapi-sys/src/lib.rs
@@ -1,3 +1,4 @@
+//! This library contains OS-specific bindings to the C `ittapi` library.
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![allow(unused)]
 
@@ -19,3 +20,11 @@ include!("linux/jitprofiling_bindings.rs");
 include!("macos/jitprofiling_bindings.rs");
 #[cfg(target_os = "windows")]
 include!("windows/jitprofiling_bindings.rs");
+
+// #[link(name = "ittnotify", kind = "static")]
+// extern "C" {
+//     #[link_name = "__itt_domain_create_init_3_0"]
+//     pub fn __itt_domain_create_init_3_0(name: *const std::os::raw::c_char) -> *mut __itt_domain;
+//     // #[link_name = "__itt_domain_create_init_3_0"]
+//     // pub fn __itt_domain_create(name: *const std::os::raw::c_char) -> *mut __itt_domain;
+// }

--- a/ittapi-rs/ittapi/Cargo.toml
+++ b/ittapi-rs/ittapi/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ittapi-rs"
+name = "ittapi"
 version = "0.2.0"
 edition = "2021"
 authors = [
@@ -18,3 +18,6 @@ keywords = ["vtune", "profiling", "code-generation"]
 anyhow = "1.0.40"
 ittapi-sys = { path = "../ittapi-sys", version = "0.2.0" }
 log = "0.4.14"
+
+[dev-dependencies]
+scoped-env = "2.1"

--- a/ittapi-rs/ittapi/README.md
+++ b/ittapi-rs/ittapi/README.md
@@ -1,0 +1,44 @@
+# ittapi
+
+[![Build Status](https://github.com/intel/ittapi/workflows/CI/badge.svg)][ci]
+[![Documentation Status](https://docs.rs/ittapi/badge.svg)][docs]
+
+This crate allows Rust programs to use Intel&reg; Instrumentation and Tracing Technology (ITT) APIs.
+Currently, the following APIs are supported (please submit an issue or PR for additional support):
+ - a JIT notification API, a higher-level view of the C [JIT Profiling API]
+ - the Domain API
+ - the Task API
+ - the String Handle API
+ - the Event API
+
+This uses the [`ittapi-sys`] crate which depends on the C `ittapi` library.
+
+[`ittapi-sys`]: https://github.com/intel/ittapi/tree/master/ittapi-rs/ittapi-sys
+[C `ittapi` library]: https://github.com/intel/ittapi
+
+> IMPORTANT NOTE: this crate is currently only tested on Linux, macOS, and Windows platforms but
+> support for other platforms is intended; contributions are welcome!
+
+If you are interested in using VTune to profile Rust applications, you may find the following guide
+helpful: [Wasmtime Docs: Using VTune on
+Linux](https://docs.wasmtime.dev/examples-profiling-vtune.html)
+
+
+### Use
+
+```toml
+[dependencies]
+ittapi = "0.2"
+```
+
+### Build
+
+```
+cargo build
+```
+
+### Test
+
+```sh
+cargo test
+```

--- a/ittapi-rs/ittapi/src/domain.rs
+++ b/ittapi-rs/ittapi/src/domain.rs
@@ -1,0 +1,33 @@
+use crate::util::access_sys_fn;
+use std::ffi::CString;
+
+/// A domain enables tagging trace data for different modules or libraries in a program. See the
+/// [Domain API] documentation for more information.
+///
+/// [Domain API]:
+///     https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/domain-api.html
+pub struct Domain(*mut ittapi_sys::__itt_domain);
+impl Domain {
+    /// Create a new domain. Note that, if the `ittnotify` library is not initialized, this call
+    /// will succeed but the domain will be invalid; see discussion TODO.
+    ///
+    /// ```
+    /// # use ittapi::Domain;
+    /// let domain = Domain::new("test-domain");
+    /// ```
+    pub fn new(name: &str) -> Self {
+        #[cfg(unix)]
+        let create_fn = access_sys_fn!(__itt_domain_create_ptr__3_0);
+        #[cfg(windows)]
+        let create_fn = access_sys_fn!(__itt_domain_createA_ptr__3_0);
+        let c_string =
+            CString::new(name).expect("unable to create a CString; does it contain a 0 byte?");
+        let domain = unsafe { create_fn(c_string.as_ptr()) };
+        Self(domain)
+    }
+
+    /// Use the `__itt_domain` pointer internally.
+    pub(crate) fn as_ptr(&self) -> *const ittapi_sys::__itt_domain {
+        self.0 as *const _
+    }
+}

--- a/ittapi-rs/ittapi/src/event.rs
+++ b/ittapi-rs/ittapi/src/event.rs
@@ -1,0 +1,75 @@
+use std::{ffi::CString, marker::PhantomData};
+
+/// See the [Event API] documentation.
+///
+/// [Event API]: https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/event-api.html
+pub struct Event(ittapi_sys::__itt_event);
+impl Event {
+    /// Create the event.
+    pub fn new(name: &str) -> Self {
+        #[cfg(unix)]
+        let create_fn = unsafe { ittapi_sys::__itt_event_create_ptr__3_0 };
+        #[cfg(windows)]
+        let create_fn = unsafe { ittapi_sys::__itt_event_createA_ptr__3_0 };
+        if let Some(create_fn) = create_fn {
+            let c_string =
+                CString::new(name).expect("unable to create a CString; does it contain a 0 byte?");
+            let size = name
+                .len()
+                .try_into()
+                .expect("unable to fit the name length into an i32");
+            let event = unsafe { create_fn(c_string.as_ptr(), size) };
+            Self(event)
+        } else {
+            Self(-1)
+        }
+    }
+
+    /// Start the event.
+    pub fn start<'a>(&'a self) -> StartedEvent<'a> {
+        if let Some(start_fn) = unsafe { ittapi_sys::__itt_event_start_ptr__3_0 } {
+            if unsafe { start_fn(self.0) } != 0 {
+                panic!("unable to start event");
+            }
+        }
+        StartedEvent {
+            event: self.0,
+            phantom: PhantomData,
+        }
+    }
+}
+
+pub struct StartedEvent<'a> {
+    event: ittapi_sys::__itt_event,
+    phantom: PhantomData<&'a mut ()>,
+}
+
+impl StartedEvent<'_> {
+    /// End the event.
+    pub fn end(self) {
+        // Do nothing; the `Drop` implementation does the work. See discussion at
+        // https://stackoverflow.com/questions/53254645.
+    }
+}
+
+impl<'a> Drop for StartedEvent<'a> {
+    fn drop(&mut self) {
+        if let Some(end_fn) = unsafe { ittapi_sys::__itt_event_end_ptr__3_0 } {
+            if unsafe { end_fn(self.event) } != 0 {
+                panic!("unable to stop event")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanity() {
+        let event = Event::new("test");
+        let _started_event = event.start();
+        // Dropping `started_event` ends the event.
+    }
+}

--- a/ittapi-rs/ittapi/src/jit.rs
+++ b/ittapi-rs/ittapi/src/jit.rs
@@ -1,0 +1,175 @@
+//! The JIT (Just-In-Time) Profiling API provides functionality to report information about
+//! just-in-time generated code that can be used by performance tools. The [Jit] Rust structure is a
+//! high-level view of a subset of the full functionality available. See the [JIT Profiling API] for
+//! more information.
+//!
+//! [JIT Profiling API]:
+///     https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/jit-profiling-api.html
+use anyhow::Context;
+use std::{ffi::CString, os, ptr};
+
+/// Register JIT-compiled methods with a performance tool (e.g., VTune). This structure assumes
+/// single-threaded access; if your program may be multi-threaded, make sure to guard multi-threaded
+/// access with a mutex.
+#[derive(Default)]
+pub struct Jit {
+    did_shutdown: bool,
+}
+
+impl Jit {
+    /// Returns a new `MethodId` for use in `MethodLoad` events.
+    pub fn get_method_id(&self) -> MethodId {
+        MethodId(unsafe { ittapi_sys::iJIT_GetNewMethodID() })
+    }
+
+    /// Notifies any `EventType` to VTune.
+    ///
+    /// May fail if the underlying call to the ittapi's method fails.
+    pub fn notify_event(&self, mut event: EventType) -> anyhow::Result<()> {
+        let tag = event.tag();
+        let data = event.data();
+        log::trace!("notify_event: tag={:?}", tag);
+        let res = unsafe { ittapi_sys::iJIT_NotifyEvent(tag, data) };
+        if res == 1 {
+            Ok(())
+        } else {
+            anyhow::bail!("error when notifying event")
+        }
+    }
+
+    // High-level helpers.
+
+    /// Notifies VTune that a new function described by the `MethodLoadBuilder` has been jitted.
+    pub fn load_method(&self, builder: MethodLoadBuilder) -> anyhow::Result<()> {
+        let method_id = self.get_method_id();
+        let method_load = builder.build(method_id)?;
+        self.notify_event(method_load)
+    }
+
+    /// Notifies VTune that profiling is being shut down.
+    pub fn shutdown(&mut self) -> anyhow::Result<()> {
+        let res = self.notify_event(EventType::Shutdown);
+        if res.is_ok() {
+            self.did_shutdown = true;
+        }
+        res
+    }
+}
+
+impl Drop for Jit {
+    fn drop(&mut self) {
+        if !self.did_shutdown {
+            // There's not much we can do when an error happens here.
+            if let Err(err) = self.shutdown() {
+                log::error!("Error when shutting down VTune: {}", err)
+            }
+        }
+    }
+}
+
+/// Type of event to be dispatched through ittapi's JIT event API.
+pub enum EventType {
+    /// Send this event after a JITted method has been loaded into memory, and possibly JIT
+    /// compiled, but before the code is executed.
+    MethodLoadFinished(MethodLoad),
+
+    /// Send this notification to terminate profiling.
+    Shutdown,
+}
+
+impl EventType {
+    /// Returns the C event type to be used when notifying this event to VTune.
+    fn tag(&self) -> ittapi_sys::iJIT_jvm_event {
+        match self {
+            EventType::MethodLoadFinished(_) => {
+                ittapi_sys::iJIT_jvm_event_iJVM_EVENT_TYPE_METHOD_INLINE_LOAD_FINISHED
+            }
+            EventType::Shutdown => ittapi_sys::iJIT_jvm_event_iJVM_EVENT_TYPE_SHUTDOWN,
+        }
+    }
+
+    /// Returns a raw C pointer to the event-specific data that must be used when notifying this
+    /// event to VTune.
+    fn data(&mut self) -> *mut os::raw::c_void {
+        match self {
+            EventType::MethodLoadFinished(method_load) => &mut method_load.0 as *mut _ as *mut _,
+            EventType::Shutdown => ptr::null_mut(),
+        }
+    }
+}
+
+/// Newtype wrapper for a method id returned by ittapi's `iJIT_GetNewMethodID`, as returned by
+/// `VtuneState::get_method_id` in the high-level API.
+#[derive(Clone, Copy)]
+pub struct MethodId(u32);
+
+/// Newtype wrapper for a JIT method load.
+pub struct MethodLoad(ittapi_sys::_iJIT_Method_Load);
+
+/// Multi-step constructor using the builder pattern for a `MethodLoad` event.
+pub struct MethodLoadBuilder {
+    method_name: String,
+    addr: *const u8,
+    len: usize,
+    class_file_name: Option<String>,
+    source_file_name: Option<String>,
+}
+
+impl MethodLoadBuilder {
+    /// Creates a new `MethodLoadBuilder` from scratch.
+    ///
+    /// `addr` is the pointer to the start of the code region, `len` is the size of this code
+    /// region in bytes.
+    pub fn new(method_name: String, addr: *const u8, len: usize) -> Self {
+        Self {
+            method_name,
+            addr,
+            len,
+            class_file_name: None,
+            source_file_name: None,
+        }
+    }
+
+    /// Attache a class file.
+    pub fn class_file_name(mut self, class_file_name: String) -> Self {
+        self.class_file_name = Some(class_file_name);
+        self
+    }
+
+    /// Attach a source file.
+    pub fn source_file_name(mut self, source_file_name: String) -> Self {
+        self.source_file_name = Some(source_file_name);
+        self
+    }
+
+    /// Build a "method load" event for the given `method_id`.
+    pub fn build(self, method_id: MethodId) -> anyhow::Result<EventType> {
+        Ok(EventType::MethodLoadFinished(MethodLoad(
+            ittapi_sys::_iJIT_Method_Load {
+                method_id: method_id.0,
+                method_name: CString::new(self.method_name)
+                    .context("CString::new failed")?
+                    .into_raw(),
+                method_load_address: self.addr as *mut os::raw::c_void,
+                method_size: self.len as u32,
+                line_number_size: 0,
+                line_number_table: ptr::null_mut(),
+                class_id: 0, // Field officially obsolete in Intel's doc.
+                class_file_name: CString::new(
+                    self.class_file_name
+                        .as_deref()
+                        .unwrap_or("<unknown class file name>"),
+                )
+                .context("CString::new failed")?
+                .into_raw(),
+                source_file_name: CString::new(
+                    self.source_file_name
+                        .as_deref()
+                        .unwrap_or("<unknown source file name>"),
+                )
+                .context("CString::new failed")?
+                .into_raw(),
+            },
+        )))
+    }
+}

--- a/ittapi-rs/ittapi/src/jit.rs
+++ b/ittapi-rs/ittapi/src/jit.rs
@@ -13,7 +13,7 @@ use std::{ffi::CString, os, ptr};
 /// access with a mutex.
 #[derive(Default)]
 pub struct Jit {
-    did_shutdown: bool,
+    shutdown_complete: bool,
 }
 
 impl Jit {
@@ -50,7 +50,7 @@ impl Jit {
     pub fn shutdown(&mut self) -> anyhow::Result<()> {
         let res = self.notify_event(EventType::Shutdown);
         if res.is_ok() {
-            self.did_shutdown = true;
+            self.shutdown_complete = true;
         }
         res
     }
@@ -58,7 +58,7 @@ impl Jit {
 
 impl Drop for Jit {
     fn drop(&mut self) {
-        if !self.did_shutdown {
+        if !self.shutdown_complete {
             // There's not much we can do when an error happens here.
             if let Err(err) = self.shutdown() {
                 log::error!("Error when shutting down VTune: {}", err)

--- a/ittapi-rs/ittapi/src/lib.rs
+++ b/ittapi-rs/ittapi/src/lib.rs
@@ -1,6 +1,6 @@
 //! This library allows Rust programs to use Intel&reg; Instrumentation and Tracing Technology (ITT)
 //! APIs. These APIs are declared by a static library, [`ittnotify`], and dynamically used by
-//! performance collection tools (e.g., VTune).
+//! performance collection tools (e.g., 'libittnotify_collector.so', VTune Profiler).
 //!
 //! [`ittnotify`]: https://github.com/intel/ittapi
 

--- a/ittapi-rs/ittapi/src/string.rs
+++ b/ittapi-rs/ittapi/src/string.rs
@@ -1,0 +1,52 @@
+use crate::util::access_sys_fn;
+use std::ffi::CString;
+
+/// String handles are ITT's mechanism for efficiently naming objects. See the [String Handle API]
+/// documentation for more information.
+///
+/// [String Handle API]:
+///     https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/string-handle-api.html
+#[derive(PartialEq, Debug)]
+pub struct StringHandle(*mut ittapi_sys::__itt_string_handle);
+impl StringHandle {
+    /// Create a new string handle; repeated calls with the same `name` will return the same handle.
+    ///
+    /// ```
+    /// # use ittapi::StringHandle;
+    /// let a = StringHandle::new("test");
+    /// let b: StringHandle = "test".into();
+    /// assert_eq!(a, b);
+    /// ```
+    pub fn new(name: &str) -> Self {
+        #[cfg(unix)]
+        let create_fn = access_sys_fn!(__itt_string_handle_create_ptr__3_0);
+        #[cfg(windows)]
+        let create_fn = access_sys_fn!(__itt_string_handle_createA_ptr__3_0);
+        let c_string =
+            CString::new(name).expect("unable to create a CString; does it contain a 0 byte?");
+        let handle = unsafe { create_fn(c_string.as_ptr()) };
+        Self(handle)
+    }
+
+    /// Use the `__itt_string_handle` pointer internally.
+    pub(crate) fn as_ptr(&self) -> *mut ittapi_sys::__itt_string_handle {
+        self.0
+    }
+}
+
+impl From<&str> for StringHandle {
+    fn from(name: &str) -> Self {
+        StringHandle::new(name)
+    }
+}
+
+mod tests {
+    #[test]
+    fn with_dynamic_part_specified() {
+        // When INTEL_LIBITTNOTIFY64 is set in the environment, the static part of ittnotify will
+        // allocate; otherwise, if the dynamic part is not present, the pointer will be null.
+        // let _env_path = scoped_env::ScopedEnv::set("INTEL_LIBITTNOTIFY64", "<some path>");
+        let sh = super::StringHandle::new("test2");
+        assert!(sh.as_ptr().is_null());
+    }
+}

--- a/ittapi-rs/ittapi/src/task.rs
+++ b/ittapi-rs/ittapi/src/task.rs
@@ -1,0 +1,72 @@
+use crate::{domain::Domain, string::StringHandle};
+
+/// A task is a logical unit of work performed by a particular thread. See the [Task API]
+/// documentation for more information.
+///
+/// [Task API]:
+///     https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/task-api.html
+///
+/// ```
+/// # use ittapi::{Domain, StringHandle, Task};
+/// let _env_path = scoped_env::ScopedEnv::set("INTEL_LIBITTNOTIFY64", "<some path>");
+/// let domain = Domain::new("domain");
+/// let name = StringHandle::new("task");
+/// // Measure a task using a pre-initialized string handle (most efficient).
+/// {
+///     let task = Task::begin(&domain, name);
+///     let _ = 2 + 2;
+///     task.end(); // Task ended here.
+///     let _ = 3 + 3;
+/// }
+/// // Measure a task using a string reference (most convenient).
+/// {
+///     let _task = Task::begin(&domain, "task");
+///     let _ = 2 + 2;
+///     // Task ended here, when dropped.
+/// }
+/// ```
+pub struct Task<'a>(&'a Domain);
+impl<'a> Task<'a> {
+    /// Start a task on the current thread.
+    pub fn begin(domain: &'a Domain, name: impl Into<StringHandle>) -> Self {
+        if let Some(create_fn) = unsafe { ittapi_sys::__itt_task_begin_ptr__3_0 } {
+            // Currently the `taskid` and `parentid` parameters are unimplemented (TODO).
+            unsafe { create_fn(domain.as_ptr(), ITT_NULL, ITT_NULL, name.into().as_ptr()) };
+        }
+        Self(domain)
+    }
+
+    /// Finish the task.
+    pub fn end(self) {
+        // Do nothing; the `Drop` implementation does the work. See discussion at
+        // https://stackoverflow.com/questions/53254645.
+    }
+}
+
+impl<'a> Drop for Task<'a> {
+    fn drop(&mut self) {
+        // If `ittnotify` has not been initialized, this function may not be wired up.
+        if let Some(end_fn) = unsafe { ittapi_sys::__itt_task_end_ptr__3_0 } {
+            unsafe { end_fn(self.0.as_ptr()) }
+        }
+    }
+}
+
+/// Using the `__itt_null` symbol results in errors so we redefine it here.
+const ITT_NULL: ittapi_sys::__itt_id = ittapi_sys::__itt_id {
+    d1: 0,
+    d2: 0,
+    d3: 0,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanity() {
+        let domain = Domain::new("domain");
+        let name = StringHandle::new("task");
+        let _task = Task::begin(&domain, name);
+    }
+}

--- a/ittapi-rs/ittapi/src/util.rs
+++ b/ittapi-rs/ittapi/src/util.rs
@@ -1,7 +1,8 @@
 /// Provide a convenient way to access ittapi functions that may have not been initialized. The
-/// `ittnotify` library has a static part (e.g., `libittnotify.a`) and a dynamic part (e.g., VTune).
-/// The static part provides the ITT symbols to the application but these may not be resolved to
-/// actual implementations in the dynamic part--the data collector.
+/// `ittnotify` library has a static part (e.g., `libittnotify.a`) and a dynamic part (e.g.,
+/// 'libittnotify_collector.so', VTune Profiler). The static part provides the ITT symbols to the
+/// application but these may not be resolved to actual implementations in the dynamic part--the
+/// data collector.
 macro_rules! access_sys_fn {
     ($fn_name: ident) => {
         unsafe {

--- a/ittapi-rs/ittapi/src/util.rs
+++ b/ittapi-rs/ittapi/src/util.rs
@@ -1,0 +1,17 @@
+/// Provide a convenient way to access ittapi functions that may have not been initialized. The
+/// `ittnotify` library has a static part (e.g., `libittnotify.a`) and a dynamic part (e.g., VTune).
+/// The static part provides the ITT symbols to the application but these may not be resolved to
+/// actual implementations in the dynamic part--the data collector.
+macro_rules! access_sys_fn {
+    ($fn_name: ident) => {
+        unsafe {
+            ittapi_sys::$fn_name.expect(concat!(
+                "unable to access the ittapi function: ",
+                stringify!($fn_name)
+            ))
+        }
+    };
+}
+
+// This allows the macro to be used internally without being published.
+pub(crate) use access_sys_fn;


### PR DESCRIPTION
This change refactors the code @bnjbvr added to the `ittapi` crate to support a few new ITT APIs: domains, tasks, events, string handles (a full list is available [here](https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference.html)). It also improves the documentation and adds tests for the new APIs. Another addition is an `integration-test` crate that checks that a system configured with VTune will be able to actually collect data using the Rust crate.