### PR TITLE
ci: check that both Rust crates are publishable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,5 @@ jobs:
       run: cargo build
     - name: Test Rust crate
       run: cargo test
-    # For some strange reason, the process of building the upstream library will result in source
-    # file changes on Windows; once this is resolved, remove `--allow-dirty`.
-    - name: Check crate is publishable
-      run: cargo publish --manifest-path ./ittapi-sys/Cargo.toml --dry-run --allow-dirty
+    - name: Check crates are publishable
+      run: scripts/verify-publish.sh

--- a/rust/scripts/.gitignore
+++ b/rust/scripts/.gitignore
@@ -1,0 +1,2 @@
+.cargo
+vendor

--- a/rust/scripts/verify-publish.sh
+++ b/rust/scripts/verify-publish.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Check that the Rust crates can all be packaged up for publication. This cannot use use `cargo
+# publish --dry-run` because of the dependency between ittapi and ittapi-sys.
+set -e
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $SCRIPT_DIR
+
+# Vendor all dependencies into the `vendor` directory and configure Cargo to look there for
+# dependencies. This is necessary so that we can package up ittapi-sys there and ittapi can refer to
+# it.
+rm -rf .cargo vendor
+cargo vendor
+mkdir .cargo
+cat > .cargo/config.toml << EOT
+[source.crates-io]
+replace-with = "vendored-sources"
+[source.vendored-sources]
+directory = "vendor"
+EOT
+
+# Package up ittapi-sys and place it in the vendor directory.
+cargo package --manifest-path ../ittapi-sys/Cargo.toml
+pushd vendor
+tar xf ../../target/package/ittapi-sys-0.*.crate
+ITTAPI_SYS_DIR=$(echo ittapi-sys-0.*)
+echo '{"files":{}}' > $ITTAPI_SYS_DIR/.cargo-checksum.json
+popd
+
+# Package up ittapi.
+cargo package --manifest-path ../ittapi/Cargo.toml
+popd


### PR DESCRIPTION
With the split to two crates, the CI should now check that both can be packaged up for publishing.