### PR TITLE
rust: release the `ittapi` and `ittapi-sys` crates

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.3.0] - 2022-04-06
 ### Changed
 - Split the functionality into two crates: `ittapi-sys` for the low-level C bindings and `ittapi`
   for new high-level APIs (e.g., Domain, Task, etc.)

--- a/rust/ittapi-sys/Cargo.toml
+++ b/rust/ittapi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ittapi-sys"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Johnnie Birch <45402135+jlb6740@users.noreply.github.com>"]
 edition = "2018"
 description = "Rust bindings for ittapi"

--- a/rust/ittapi-sys/Cargo.toml
+++ b/rust/ittapi-sys/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["vtune", "profiling", "code-generation"]
 [dependencies]
 
 [build-dependencies]
-cc = "1.0.72"
+cc = "1.0.73"
 
 [dev-dependencies]
 bindgen = "0.59"

--- a/rust/ittapi/Cargo.toml
+++ b/rust/ittapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ittapi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = [
     "Johnnie Birch <45402135+jlb6740@users.noreply.github.com>",
@@ -16,7 +16,7 @@ keywords = ["vtune", "profiling", "code-generation"]
 
 [dependencies]
 anyhow = "1.0.40"
-ittapi-sys = { path = "../ittapi-sys", version = "0.2.0" }
+ittapi-sys = { path = "../ittapi-sys", version = "0.3.0" }
 log = "0.4.14"
 
 [dev-dependencies]

--- a/rust/ittapi/Cargo.toml
+++ b/rust/ittapi/Cargo.toml
@@ -15,9 +15,9 @@ repository = "https://github.com/intel/ittapi"
 keywords = ["vtune", "profiling", "code-generation"]
 
 [dependencies]
-anyhow = "1.0.40"
+anyhow = "1.0.56"
 ittapi-sys = { path = "../ittapi-sys", version = "0.3.0" }
-log = "0.4.14"
+log = "0.4.16"
 
 [dev-dependencies]
 scoped-env = "2.1"


### PR DESCRIPTION
This PR will bump the versions of the now-separate `ittapi` and
`ittapi-sys` crates to 0.3.0. Once published, we will separately
deprecate the `ittapi-rs` crate by changing the README to a deprecation
notice. Also, this updates the few dependencies of these crates.