### PR TITLE
rust: fix PowerShell script paths

### DIFF
--- a/rust/ittapi-sys/scripts/copy-c-library.ps1
+++ b/rust/ittapi-sys/scripts/copy-c-library.ps1
@@ -1,8 +1,0 @@
-# Copy the source code of the C library into `rust/c-library`. This is a workaround for Windows
-# developers that may not be able to use POSIX symlinks. Also see:
-# https://github.com/git-for-windows/git/wiki/Symbolic-Links.
-$cLibrary = $MyInvocation.MyCommand.Path | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent
-$rustLibrary = Join-Path -Path $cLibrary -ChildPath "rust"
-$linkLocation = Join-Path -Path $rustLibrary -ChildPath "c-library"
-Remove-Item $linkLocation -Force -Recurse
-robocopy $cLibrary $linkLocation /e /xd ".git" "build" "rust"

--- a/rust/scripts/copy-c-library.ps1
+++ b/rust/scripts/copy-c-library.ps1
@@ -1,0 +1,7 @@
+# Copy the source code of the C library into `rust/ittapi-sys/c-library`. This is a workaround for
+# Windows developers that may not be able to use POSIX symlinks. Also see:
+# https://github.com/git-for-windows/git/wiki/Symbolic-Links.
+$cLibrary = $MyInvocation.MyCommand.Path | Split-Path -Parent | Split-Path -Parent | Split-Path -Parent
+$linkLocation = Join-Path -Path $cLibrary -ChildPath "rust" | Join-Path -ChildPath "ittapi-sys" | Join-Path -ChildPath "c-library"
+Remove-Item $linkLocation -Force -Recurse
+robocopy $cLibrary $linkLocation /e /xd ".git" "build" "rust"


### PR DESCRIPTION
With the move to two crates, the paths to copy the c-library files needed updating.