### PR TITLE
rust: turn on clippy in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,9 @@ jobs:
         working-directory: rust
     steps:
     - uses: actions/checkout@v2
-    - run: rustup component add rustfmt
+    - run: rustup component add rustfmt clippy
     - run: cargo fmt --all -- --check
+    - run: cargo clippy
 
   rust_dependencies:
     name: Check Rust dependencies

--- a/rust/clippy.toml
+++ b/rust/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["VTune"]

--- a/rust/ittapi-sys/Cargo.toml
+++ b/rust/ittapi-sys/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 homepage  = "https://github.com/intel/ittapi/tree/master/rust/ittapi-sys"
 repository = "https://github.com/intel/ittapi"
 keywords = ["vtune", "profiling", "code-generation"]
+categories = ["development-tools", "external-ffi-bindings"]
 
 [dependencies]
 

--- a/rust/ittapi-sys/build.rs
+++ b/rust/ittapi-sys/build.rs
@@ -1,6 +1,7 @@
 //! Build the `ittapi` C library in the parent directory. The `cc` configuration here should match
-//! that of the parent directories `CMakeLists.txt` (TODO: keep these in sync,
-//! https://github.com/intel/ittapi/issues/36).
+//! that of the parent directories `CMakeLists.txt` (TODO: keep these in sync, see [#36]).
+//!
+//! [#36]: https://github.com/intel/ittapi/issues/36
 
 fn main() {
     cc::Build::new()

--- a/rust/ittapi-sys/src/lib.rs
+++ b/rust/ittapi-sys/src/lib.rs
@@ -1,6 +1,10 @@
 //! This library contains OS-specific bindings to the C `ittapi` library.
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![allow(unused)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(clippy::unreadable_literal)]
 
 // The ITT bindings are OS-specific: they contain OS-specific constants (e.g. `ITT_OS` and
 // `ITT_PLATFORM`) and some of the Windows structure sizes are different. Because of this, we

--- a/rust/ittapi/Cargo.toml
+++ b/rust/ittapi/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 homepage  = "https://github.com/intel/ittapi/tree/master/rust/ittapi"
 repository = "https://github.com/intel/ittapi"
 keywords = ["vtune", "profiling", "code-generation"]
+categories = ["development-tools"]
 
 [dependencies]
 anyhow = "1.0.56"

--- a/rust/ittapi/src/event.rs
+++ b/rust/ittapi/src/event.rs
@@ -26,11 +26,14 @@ impl Event {
     }
 
     /// Start the event.
-    pub fn start<'a>(&'a self) -> StartedEvent<'a> {
+    ///
+    /// # Panics
+    ///
+    /// This will panic if the ITT library cannot start the event.
+    pub fn start(&self) -> StartedEvent {
         if let Some(start_fn) = unsafe { ittapi_sys::__itt_event_start_ptr__3_0 } {
-            if unsafe { start_fn(self.0) } != 0 {
-                panic!("unable to start event");
-            }
+            let result = unsafe { start_fn(self.0) };
+            assert!(result == 0, "unable to start event");
         }
         StartedEvent {
             event: self.0,
@@ -46,6 +49,7 @@ pub struct StartedEvent<'a> {
 
 impl StartedEvent<'_> {
     /// End the event.
+    #[allow(clippy::unused_self)]
     pub fn end(self) {
         // Do nothing; the `Drop` implementation does the work. See discussion at
         // https://stackoverflow.com/questions/53254645.
@@ -55,9 +59,8 @@ impl StartedEvent<'_> {
 impl<'a> Drop for StartedEvent<'a> {
     fn drop(&mut self) {
         if let Some(end_fn) = unsafe { ittapi_sys::__itt_event_end_ptr__3_0 } {
-            if unsafe { end_fn(self.event) } != 0 {
-                panic!("unable to stop event")
-            }
+            let result = unsafe { end_fn(self.event) };
+            assert!(result == 0, "unable to stop event");
         }
     }
 }

--- a/rust/ittapi/src/lib.rs
+++ b/rust/ittapi/src/lib.rs
@@ -1,10 +1,18 @@
 //! This library allows Rust programs to use Intel&reg; Instrumentation and Tracing Technology (ITT)
 //! APIs. These APIs are declared by a static library, [`ittnotify`], and dynamically used by
-//! performance collection tools (e.g., 'libittnotify_collector.so', VTune Profiler).
+//! performance collection tools (e.g., `libittnotify_collector.so`, VTune Profiler).
 //!
 //! [`ittnotify`]: https://github.com/intel/ittapi
-
 #![deny(missing_docs)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(
+    clippy::return_self_not_must_use,
+    clippy::must_use_candidate,
+    clippy::module_name_repetitions
+)]
+
 mod domain;
 mod event;
 pub mod jit;

--- a/rust/ittapi/src/string.rs
+++ b/rust/ittapi/src/string.rs
@@ -36,7 +36,7 @@ impl StringHandle {
 
 impl From<&str> for StringHandle {
     fn from(name: &str) -> Self {
-        StringHandle::new(name)
+        Self::new(name)
     }
 }
 

--- a/rust/ittapi/src/task.rs
+++ b/rust/ittapi/src/task.rs
@@ -37,6 +37,7 @@ impl<'a> Task<'a> {
     }
 
     /// Finish the task.
+    #[allow(clippy::unused_self)]
     pub fn end(self) {
         // Do nothing; the `Drop` implementation does the work. See discussion at
         // https://stackoverflow.com/questions/53254645.

--- a/rust/ittapi/src/util.rs
+++ b/rust/ittapi/src/util.rs
@@ -1,6 +1,6 @@
 /// Provide a convenient way to access ittapi functions that may have not been initialized. The
 /// `ittnotify` library has a static part (e.g., `libittnotify.a`) and a dynamic part (e.g.,
-/// 'libittnotify_collector.so', VTune Profiler). The static part provides the ITT symbols to the
+/// `libittnotify_collector.so`, VTune Profiler). The static part provides the ITT symbols to the
 /// application but these may not be resolved to actual implementations in the dynamic part--the
 /// data collector.
 macro_rules! access_sys_fn {


### PR DESCRIPTION
This change turns on clippy static analysis during CI runs. Many of the
changes to make this pass are pedantic, but some are interesting (e.g.,
integer truncation, better documentation, clearer error handling).