### PR TITLE
rust: release 0.3.1

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2022-04-12
+### Changed
+- Make high-level `Domain` structure `Sync`
+
 ## [0.3.0] - 2022-04-06
 ### Changed
 - Split the functionality into two crates: `ittapi-sys` for the low-level C bindings and `ittapi`

--- a/rust/ittapi-sys/Cargo.toml
+++ b/rust/ittapi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ittapi-sys"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Johnnie Birch <45402135+jlb6740@users.noreply.github.com>"]
 edition = "2018"
 description = "Rust bindings for ittapi"

--- a/rust/ittapi/Cargo.toml
+++ b/rust/ittapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ittapi"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = [
     "Johnnie Birch <45402135+jlb6740@users.noreply.github.com>",
@@ -17,7 +17,7 @@ categories = ["development-tools"]
 
 [dependencies]
 anyhow = "1.0.56"
-ittapi-sys = { path = "../ittapi-sys", version = "0.3.0" }
+ittapi-sys = { path = "../ittapi-sys", version = "0.3.1" }
 log = "0.4.16"
 
 [dev-dependencies]


### PR DESCRIPTION
Include all recent changes in a new release for external use.