### PR TITLE
ci: use GitHub's updated version of MinGW

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,17 +69,6 @@ jobs:
       if: matrix.target != ''
     - run: echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
       if: matrix.target != ''
-    - name: Upgrade MinGW package
-      # In https://github.com/bytecodealliance/wasmtime/pull/4003 we discovered that the ittapi C
-      # code uses the uncommon `strnlen_s` function. On older versions of MinGW (GitHub runners
-      # currently come with v8.1.0 pre-installed), this function was not available. Since v8.1.0,
-      # other versions have been published; this re-installs MinGW with a recent version which
-      # includes `strnlen_s`. This block can be removed if/when MinGW is upgraded in all Windows
-      # GitHub runners: https://github.com/actions/virtual-environments/issues/5530.
-      if: matrix.target == 'x86_64-pc-windows-gnu'
-      run: |
-           choco uninstall mingw
-           choco install mingw --version 11.2.0 --force
     - name: Build Rust crate
       run: cargo build
     - name: Test Rust crate


### PR DESCRIPTION
Now that https://github.com/actions/virtual-environments/pull/5729 has
merged, GitHub runners using `windows-latest` (i.e., Windows 2022)
should have a later version of MinGW (i.e., 11.2.0) that solves the
build issues observed in this repository. Recall that the `strnlen_s`
function is not available on older versions of MinGW but was necessary
to compile the C library. With this change, CI will use GitHub's MinGW
version instead of manually installing a new one.