### PR TITLE
Suppress CMake policy warning (CMP0048)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@
 
 cmake_minimum_required(VERSION 2.8.12)
 
+if (POLICY CMP0048)
+    # The `project()` command manages `VERSION` variables
+    cmake_policy(SET CMP0048 NEW)
+endif()
+
 project(ittapi)
 
 OPTION(FORCE_32 "Force a 32bit compile on 64bit" OFF)


### PR DESCRIPTION
Set `cmake_policy` CMP0048 to NEW before `project` command to suppress the following warning introduced in CMake 3.22:

```
CMake Warning (dev) at CMakeLists.txt:9 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    CMAKE_PROJECT_VERSION
    CMAKE_PROJECT_VERSION_MAJOR
    CMAKE_PROJECT_VERSION_MINOR
    CMAKE_PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```

NEW policy sets `VERSION` variables to empty values, while `OLD` policy leaves them unchanged. Please note that setting policy to `OLD` results in deprecated warning saying that it will be removed in future CMake versions.