### PR TITLE
rust: release v0.3.2

### DIFF
--- a/rust/ittapi-sys/Cargo.toml
+++ b/rust/ittapi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ittapi-sys"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Johnnie Birch <45402135+jlb6740@users.noreply.github.com>"]
 edition = "2018"
 description = "Rust bindings for ittapi"

--- a/rust/ittapi/Cargo.toml
+++ b/rust/ittapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ittapi"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = [
     "Johnnie Birch <45402135+jlb6740@users.noreply.github.com>",
@@ -17,7 +17,7 @@ categories = ["development-tools"]
 
 [dependencies]
 anyhow = "1.0.56"
-ittapi-sys = { path = "../ittapi-sys", version = "0.3.1" }
+ittapi-sys = { path = "../ittapi-sys", version = "0.3.2" }
 log = "0.4.16"
 
 [dev-dependencies]

--- a/rust/scripts/verify-publish.sh
+++ b/rust/scripts/verify-publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Check that the Rust crates can all be packaged up for publication. This cannot use use `cargo
-# publish --dry-run` because of the dependency between ittapi and ittapi-sys.
+# Check that the Rust crates can all be packaged up for publication. This cannot use `cargo publish
+# --dry-run` because of the dependency between `ittapi` and `ittapi-sys``.
 set -e
 
 SCRIPT_ARGS=${@:1}


### PR DESCRIPTION
Bump the version of the Rust crates in preparation for a new release with the new "collection control" API.