### PR TITLE
ci: exit with correct OS exit code

### DIFF
--- a/buildall.py
+++ b/buildall.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 #
 # Copyright (C) 2005-2019 Intel Corporation
 #
@@ -15,7 +15,9 @@ import subprocess
 
 def run_shell(cmd):
     print("\n>>", cmd)
-    os.system(cmd)
+    code = os.system(cmd)
+    if code != 0:
+        sys.exit(">> failed to run shell command: %s" % cmd)
 
 
 if sys.platform == 'win32':


### PR DESCRIPTION
This addresses part of #62. With this change, running `python buildall.py` to a failure state will return the correct OS exit code. This should highlight in the CI anything that might be broken with the C CI tasks.