### PR TITLE
ci: correctly ignore build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build
+/build_*


### PR DESCRIPTION
Previously, running `python buildall.py` would create build directories like `build_linux` that were seen as Git-committable files. This adds a line to ignore the output directories of `buildall.py`.