### PR TITLE
rust: release v0.3.3

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.3.3] - 2023-01-18
+### Added
+- FreeBSD support; the crate now contains bindings for Windows, Linux, macOS, and FreeBSD
+
 ## [0.3.2] - 2022-11-14
 ### Added
 - Add `pause`, `resume`, and `detach` functions

--- a/rust/ittapi-sys/Cargo.toml
+++ b/rust/ittapi-sys/Cargo.toml
@@ -18,5 +18,5 @@ categories = ["development-tools", "external-ffi-bindings"]
 cc = "1.0.73"
 
 [dev-dependencies]
-bindgen = "0.63"
+bindgen = "0.59"
 diff = "0.1"

--- a/rust/ittapi-sys/Cargo.toml
+++ b/rust/ittapi-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ittapi-sys"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Johnnie Birch <45402135+jlb6740@users.noreply.github.com>"]
 edition = "2018"
 description = "Rust bindings for ittapi"
@@ -18,5 +18,5 @@ categories = ["development-tools", "external-ffi-bindings"]
 cc = "1.0.73"
 
 [dev-dependencies]
-bindgen = "0.59"
+bindgen = "0.63"
 diff = "0.1"

--- a/rust/ittapi-sys/README.md
+++ b/rust/ittapi-sys/README.md
@@ -14,7 +14,8 @@ Profiling API. More details about `ittapi` are available on its [README].
 [README]: https://github.com/intel/ittapi#readme
 
 > IMPORTANT NOTE: this crate is currently only tested on Linux, macOS, and Windows platforms but
-> support for other platforms is intended; contributions are welcome!
+> support for other platforms is intended; contributions are welcome! FreeBSD is supported but
+> untested.
 
 If you are interested in using VTune to profile Rust applications, you may find the following guide
 helpful: [Wasmtime Docs: Using VTune on

--- a/rust/ittapi/Cargo.toml
+++ b/rust/ittapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ittapi"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = [
     "Johnnie Birch <45402135+jlb6740@users.noreply.github.com>",
@@ -17,7 +17,7 @@ categories = ["development-tools"]
 
 [dependencies]
 anyhow = "1.0.56"
-ittapi-sys = { path = "../ittapi-sys", version = "0.3.2" }
+ittapi-sys = { path = "../ittapi-sys", version = "0.3.3" }
 log = "0.4.16"
 
 [dev-dependencies]

--- a/rust/ittapi/README.md
+++ b/rust/ittapi/README.md
@@ -21,7 +21,8 @@ This uses the [`ittapi-sys`] crate which depends on the [C `ittapi` library].
 [C `ittapi` library]: https://github.com/intel/ittapi
 
 > IMPORTANT NOTE: this crate is currently only tested on Linux, macOS, and Windows platforms but
-> support for other platforms is intended; contributions are welcome!
+> support for other platforms is intended; contributions are welcome! FreeBSD is supported but
+> untested.
 
 If you are interested in using VTune to profile Rust applications, you may find the following guide
 helpful: [Wasmtime Docs: Using VTune on


### PR DESCRIPTION
Bump the version of the Rust crates to release FreeBSD support.