### PR TITLE
rust: exclude unnecessary files from `ittapi-sys` crate

### DIFF
--- a/rust/ittapi-sys/Cargo.toml
+++ b/rust/ittapi-sys/Cargo.toml
@@ -11,6 +11,7 @@ homepage  = "https://github.com/intel/ittapi/tree/master/rust/ittapi-sys"
 repository = "https://github.com/intel/ittapi"
 keywords = ["vtune", "profiling", "code-generation"]
 categories = ["development-tools", "external-ffi-bindings"]
+exclude = ["c-library/.git", "c-library/.github", "c-library/.vscode", "c-library/build*"]
 
 [dependencies]
 


### PR DESCRIPTION
This removes files like the `.git` history from the packaged files. Verified with `cargo package --list`.