### PR TITLE
rust: improve error checking and avoid double shutdown

### DIFF
--- a/rust/ittapi/src/jit.rs
+++ b/rust/ittapi/src/jit.rs
@@ -61,6 +61,9 @@ impl Jit {
     ///
     /// May fail if the ITT library fails to notify the shutdown event.
     pub fn shutdown(&mut self) -> anyhow::Result<()> {
+        if self.shutdown_complete {
+            return Ok(());
+        }
         let res = self.notify_event(EventType::Shutdown);
         if res.is_ok() {
             self.shutdown_complete = true;


### PR DESCRIPTION
The documentation of the `iJIT_METHOD_LOAD` event states that when calling into `notify_event` with that event, the return type is undefined, so we can't really tell whether that worked or not. So far, the library assumed that this would return 1, which is only the case when the event type is `SHUTDOWN`. This PR fixes that.

Also, avoid a double shutdown. I don't know if this prevents actual issues, but better be safe than sorry.