### PR TITLE
Remove large and unnecessary fortran objects

### DIFF
--- a/rust/ittapi-sys/Cargo.toml
+++ b/rust/ittapi-sys/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools", "external-ffi-bindings"]
 exclude = [
     "c-library/.git",
     "c-library/.github",
+    "c-library/.vscode",
     "c-library/build*",
     "c-library/CMakeLists.txt",
     "c-library/cmake",

--- a/rust/ittapi-sys/Cargo.toml
+++ b/rust/ittapi-sys/Cargo.toml
@@ -14,8 +14,11 @@ categories = ["development-tools", "external-ffi-bindings"]
 exclude = [
     "c-library/.git",
     "c-library/.github",
-    "c-library/.vscode",
     "c-library/build*",
+    "c-library/CMakeLists.txt",
+    "c-library/cmake",
+    "c-library/include/fortran",
+    "c-library/include/AdvisorAnnotate.cs",
 ]
 
 [dependencies]


### PR DESCRIPTION
There are several precompiled fortran object files included in the rust package that are completely unnecessary, bloating the package.