### PR TITLE
rust: specify Cargo resolver

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,3 @@
 [workspace]
-members = [
-    "ittapi-sys",
-    "ittapi",
-]
+resolver = '2'
+members = ["ittapi-sys", "ittapi"]


### PR DESCRIPTION
This eliminates some unnecessary Cargo warnings.