### PR TITLE
rust: use a different `METHOD_LOAD` event

### DIFF
--- a/rust/ittapi/src/jit.rs
+++ b/rust/ittapi/src/jit.rs
@@ -109,7 +109,7 @@ impl EventType {
     fn tag(&self) -> ittapi_sys::iJIT_jvm_event {
         match self {
             EventType::MethodLoadFinished(_) => {
-                ittapi_sys::iJIT_jvm_event_iJVM_EVENT_TYPE_METHOD_INLINE_LOAD_FINISHED
+                ittapi_sys::iJIT_jvm_event_iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED
             }
             EventType::Shutdown => ittapi_sys::iJIT_jvm_event_iJVM_EVENT_TYPE_SHUTDOWN,
         }


### PR DESCRIPTION
Previously, the Rust bindings used the `iJVM_EVENT_TYPE_METHOD_INLINE_LOAD_FINISHED` event to notify VTune of new JIT code. This may not be correct: it is unclear from the documentation, but an "inline JIT-compiled method" sounds more like self-modifying code, not typically what we think of with JIT-compiled code. JIT-compiled code, as used elsewhere (e.g., Wasmtime), is typically emitted in a memory allocation that is separate from the runtime binary code region. This change uses the `iJVM_EVENT_TYPE_METHOD_LOAD_FINISHED` event instead.