### PR TITLE
Fix memory leak in reference collector

### DIFF
--- a/src/ittnotify_refcol/itt_refcol_impl.c
+++ b/src/ittnotify_refcol/itt_refcol_impl.c
@@ -67,6 +67,7 @@ void ref_col_init()
                 sprintf(file_name_buffer,"/tmp/%s", log_file);
             #endif
         }
+        free(log_file);
 
         g_ref_collector_logger.file_name = file_name_buffer;
         g_ref_collector_logger.init_state = 1;


### PR DESCRIPTION
We allocate memory for the `log_file`  via malloc in `log_file_name_generate()` but do not free it