### PR TITLE
rust: improve `StringHandle` test

### DIFF
--- a/rust/ittapi/src/string.rs
+++ b/rust/ittapi/src/string.rs
@@ -45,12 +45,15 @@ mod tests {
     #[test]
     fn construct_string_handle() {
         let sh = super::StringHandle::new("test2");
+        // `ittapi` profiling is only enabled when the `INTEL_LIBITTNOTIFY64` environment variable
+        // is set, which points to the profiling collector. If set, the string handle is actually
+        // allocated; if not set, no allocation is performed (this is a general `ittapi` property:
+        // no allocation without a profiling collector). Note that string handles are thus invalid
+        // in the latter case--no collector--but the API safely does not provide any way to observe
+        // this.
         if std::env::var("INTEL_LIBITTNOTIFY64").is_ok() {
             assert!(!sh.as_ptr().is_null());
         } else {
-            // What this test shows (and reminds us) is that `StringHandle` has issues when the
-            // collector is not set dynamically (i.e., when INTEL_LIBITTNOTIFY64 is set in the
-            // environment).
             assert!(sh.as_ptr().is_null());
         }
     }

--- a/rust/ittapi/src/string.rs
+++ b/rust/ittapi/src/string.rs
@@ -43,11 +43,15 @@ impl From<&str> for StringHandle {
 
 mod tests {
     #[test]
-    fn with_dynamic_part_specified() {
-        // When INTEL_LIBITTNOTIFY64 is set in the environment, the static part of ittnotify will
-        // allocate; otherwise, if the dynamic part is not present, the pointer will be null.
-        let _env_path = scoped_env::ScopedEnv::remove("INTEL_LIBITTNOTIFY64");
+    fn construct_string_handle() {
         let sh = super::StringHandle::new("test2");
-        assert!(sh.as_ptr().is_null());
+        if std::env::var("INTEL_LIBITTNOTIFY64").is_ok() {
+            assert!(!sh.as_ptr().is_null());
+        } else {
+            // What this test shows (and reminds us) is that `StringHandle` has issues when the
+            // collector is not set dynamically (i.e., when INTEL_LIBITTNOTIFY64 is set in the
+            // environment).
+            assert!(sh.as_ptr().is_null());
+        }
     }
 }


### PR DESCRIPTION
PR #69 identified an issue with how the C library gives out string handles: it only does so when `INTEL_LIBITTNOTIFY64` is present in the environment. This change clarifies this in the test, though presumably at some point the C library should not be handing out null pointers or `StringHandle::new` should fail with a coherent error message.