### PR TITLE
ci: reduce the steady stream of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Disable the steady stream of version updates for actions; only notify about security updates.
+    open-pull-requests-limit: 0


### PR DESCRIPTION
PR #107 introduced dependabot to the repository to update GitHub Actions. This results in a weekly stream of PRs to incorporate every tiny patch update for every GitHub Action we use here. This results in a lot of churn and I do not have any sense that it improves the code quality in any way. Instead, it may in fact be the cause of the breakage in the release workflow, since that relies on `upload-artifact` which dependabot bumped from v3.1.3 to v4.0.0 (see #126).

What this change does is follow GitHub's [guidance] to only receive security updates. Since "dependabot security updates" are enabled, we don't need to follow each action update; setting
`open-pull-requests-limit` to 0 mutes the dependabot PRs but we should still see any security alerts in the security tab.

[guidance]: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file