### PR TITLE
Fix unsecure loading library pointed by ENV variable

### DIFF
--- a/src/ittnotify/jitprofiling.c
+++ b/src/ittnotify/jitprofiling.c
@@ -114,7 +114,7 @@ ITT_EXTERN_C iJIT_IsProfilingActiveFlags JITAPI iJIT_IsProfilingActive()
     return executionMode;
 }
 
-#if ITT_PLATFORM==ITT_PLATFORM_WIN
+#if ITT_PLATFORM == ITT_PLATFORM_WIN
 static int isValidAbsolutePath(char *path)
 {
     if (path == NULL)

--- a/src/ittnotify/jitprofiling.c
+++ b/src/ittnotify/jitprofiling.c
@@ -155,7 +155,7 @@ static int loadiJIT_Funcs()
         {
             envret = GetEnvironmentVariableA(NEW_DLL_ENVIRONMENT_VAR, 
                                              dllName, dNameLength);
-            if (envret)
+            if (envret&&!PathIsRelativeA(dllName))
             {
                 /* Try to load the dll from the PATH... */
                 m_libHandle = LoadLibraryExA(dllName, 

--- a/src/ittnotify/jitprofiling.c
+++ b/src/ittnotify/jitprofiling.c
@@ -8,6 +8,7 @@
 
 #if ITT_PLATFORM==ITT_PLATFORM_WIN
 #include <windows.h>
+#include <shlwapi.h>
 #endif /* ITT_PLATFORM==ITT_PLATFORM_WIN */
 #if ITT_PLATFORM != ITT_PLATFORM_MAC && ITT_PLATFORM != ITT_PLATFORM_FREEBSD && ITT_PLATFORM != ITT_PLATFORM_OPENBSD
 #include <malloc.h>

--- a/src/ittnotify/jitprofiling.c
+++ b/src/ittnotify/jitprofiling.c
@@ -115,24 +115,24 @@ ITT_EXTERN_C iJIT_IsProfilingActiveFlags JITAPI iJIT_IsProfilingActive()
 }
 
 #if ITT_PLATFORM==ITT_PLATFORM_WIN
-int isPathRelative(char *path)
+static int isValidAbsolutePath(char *path)
 {
     if(path==NULL)
     {
-        return 1;
+        return 0;
     }
-    else if(strlen(path)>1) 
+    else if(strlen(path)>2) 
     {
-        if(isalpha(path[0]) && path[1]==':')
+        if(isalpha(path[0]) && path[1]==':' && path[2]=='\\')
         {
-            return 0;
+            return 1;
         }
-        else if(path[0]=='\\' && path[1]=='\\')
+        else if(path[0]=='\\' && path[1]=='\\' && isalpha(path[2]))
         {
-            return 0;
+            return 1;
         }
     }
-    return 1;
+    return 0;
 }
 #endif
 
@@ -175,12 +175,11 @@ static int loadiJIT_Funcs()
     {
         DWORD envret = 0;
         dllName = (char*)malloc(sizeof(char) * (dNameLength + 1));
-        dllName[dNameLength]='\0'; // To handle a corner case to prevent out of bounds memory access. 
         if(dllName != NULL)
         {
             envret = GetEnvironmentVariableA(NEW_DLL_ENVIRONMENT_VAR, 
                                              dllName, dNameLength);
-            if (envret && !isPathRelative(dllName))
+            if (envret && isValidAbsolutePath(dllName))
             {
                 /* Try to load the dll from the PATH... */
                 m_libHandle = LoadLibraryExA(dllName, 

--- a/src/ittnotify/jitprofiling.c
+++ b/src/ittnotify/jitprofiling.c
@@ -117,17 +117,17 @@ ITT_EXTERN_C iJIT_IsProfilingActiveFlags JITAPI iJIT_IsProfilingActive()
 #if ITT_PLATFORM==ITT_PLATFORM_WIN
 static int isValidAbsolutePath(char *path)
 {
-    if(path==NULL)
+    if (path==NULL)
     {
         return 0;
     }
-    else if(strlen(path)>2) 
+    else if (strlen(path)>2) 
     {
-        if(isalpha(path[0]) && path[1]==':' && path[2]=='\\')
+        if (isalpha(path[0]) && path[1]==':' && path[2]=='\\')
         {
             return 1;
         }
-        else if(path[0]=='\\' && path[1]=='\\' && isalpha(path[2]))
+        else if (path[0]=='\\' && path[1]=='\\')
         {
             return 1;
         }

--- a/src/ittnotify/jitprofiling.c
+++ b/src/ittnotify/jitprofiling.c
@@ -117,17 +117,17 @@ ITT_EXTERN_C iJIT_IsProfilingActiveFlags JITAPI iJIT_IsProfilingActive()
 #if ITT_PLATFORM==ITT_PLATFORM_WIN
 static int isValidAbsolutePath(char *path)
 {
-    if (path==NULL)
+    if (path == NULL)
     {
         return 0;
     }
-    else if (strlen(path)>2) 
+    else if (strlen(path) > 2) 
     {
-        if (isalpha(path[0]) && path[1]==':' && path[2]=='\\')
+        if (isalpha(path[0]) && path[1] == ':' && path[2] == '\\')
         {
             return 1;
         }
-        else if (path[0]=='\\' && path[1]=='\\')
+        else if (path[0] == '\\' && path[1] == '\\')
         {
             return 1;
         }


### PR DESCRIPTION
For function `LoadLibraryExA` if `lpFileName` specifies a relative path with LOAD_WITH_ALTERED_SEARCH_PATH flag set, the behavior is undefined. 

Changes are related to adding a check for the relative path before calling function `LoadLibraryExA`.

Jenkins green build: [link](https://cje-ba-prod01.devtools.intel.com/satg-dse-ae/job/Products/job/VTune/job/parameterized-orchestrator/867/)