### PR TITLE
Make the isValidAbsolutePath function more secure by using strnlen

### DIFF
--- a/src/ittnotify/jitprofiling.c
+++ b/src/ittnotify/jitprofiling.c
@@ -123,6 +123,13 @@ static int isValidAbsolutePath(char *path, size_t maxPathLength)
     }
 
     size_t pathLength = strnlen(path, maxPathLength);
+    if (pathLength == maxPathLength)
+    {
+      /* The strnlen() function returns maxPathLength if there is no null terminating
+       * among the first maxPathLength characters in the string pointed to by path.
+       */
+      return 0;
+    }
 
     if (pathLength > 2)
     {

--- a/src/ittnotify/jitprofiling.c
+++ b/src/ittnotify/jitprofiling.c
@@ -115,13 +115,16 @@ ITT_EXTERN_C iJIT_IsProfilingActiveFlags JITAPI iJIT_IsProfilingActive()
 }
 
 #if ITT_PLATFORM == ITT_PLATFORM_WIN
-static int isValidAbsolutePath(char *path)
+static int isValidAbsolutePath(char *path, size_t maxPathLength)
 {
     if (path == NULL)
     {
         return 0;
     }
-    else if (strlen(path) > 2) 
+
+    size_t pathLength = strnlen(path, maxPathLength);
+
+    if (pathLength > 2)
     {
         if (isalpha(path[0]) && path[1] == ':' && path[2] == '\\')
         {
@@ -179,7 +182,7 @@ static int loadiJIT_Funcs()
         {
             envret = GetEnvironmentVariableA(NEW_DLL_ENVIRONMENT_VAR, 
                                              dllName, dNameLength);
-            if (envret && isValidAbsolutePath(dllName))
+            if (envret && isValidAbsolutePath(dllName, dNameLength))
             {
                 /* Try to load the dll from the PATH... */
                 m_libHandle = LoadLibraryExA(dllName, 


### PR DESCRIPTION
To make `isValidAbsolutePath` function more secure use the `strnlen` function instead of the `strlen`.
Calling the `strlen` function can potentially be unsafe. The `strlen` function calculates the length of a string by counting characters until it reaches a null character and if the string is not properly null-terminated then `strlen` will continue reading memory beyond the end of the string, which can lead to undefined behavior or a program crash.