### PR TITLE
rust: update links to VTune user guide

### DIFF
--- a/rust/integration-tests/README.md
+++ b/rust/integration-tests/README.md
@@ -13,8 +13,9 @@ source vtune-vars.sh
 cargo test
 ```
 
-To install VTune, see the [User
-Guide](https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/installation.html).
-The environment setup script (e.g., `vtune-vars.sh`) can be found within the VTune installation;
-e.g., `$HOME/intel/oneapi/vtune/latest` or `/opt/intel/oneapi/vtune/latest` on
-[Linux](https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-vtune/top/linux-os.html).
+To install VTune, see the [User Guide]. The environment setup script (e.g., `vtune-vars.sh`) can be
+found within the VTune installation; e.g., `$HOME/intel/oneapi/vtune/latest` or
+`/opt/intel/oneapi/vtune/latest` on [Linux].
+
+[User Guide]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/installation.html
+[Linux]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/get-started-guide/2024-1/linux-os.html

--- a/rust/integration-tests/tests/main.rs
+++ b/rust/integration-tests/tests/main.rs
@@ -41,7 +41,7 @@ fn run_with_collector() {
 
     // Finally, check that the created report actually contains the measured tasks. It may be
     // interesting to filter by task here: e.g.,
-    // https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/command-line-interface/generating-command-line-reports/filtering-and-grouping-reports.html.
+    // https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/filtering-and-grouping-reports.html
     let report_stdout = run(&["vtune", "-report", "summary", result_dir_flag]);
     assert!(report_stdout.contains("task#1 "));
     assert!(report_stdout.contains("task#2 "));

--- a/rust/ittapi/src/collection_control.rs
+++ b/rust/ittapi/src/collection_control.rs
@@ -37,7 +37,7 @@
 /// // Do finalization work here
 /// ```
 ///
-/// [Collection Control API]: https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/collection-control-api.html
+/// [Collection Control API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/collection-control-api.html
 pub fn pause() {
     if let Some(pause_fn) = unsafe { ittapi_sys::__itt_pause_ptr__3_0 } {
         unsafe { (pause_fn)() };
@@ -54,7 +54,7 @@ pub fn pause() {
 ///
 /// See [pause#example].
 ///
-/// [Collection Control API]: https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/collection-control-api.html
+/// [Collection Control API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/collection-control-api.html
 pub fn resume() {
     if let Some(resume_fn) = unsafe { ittapi_sys::__itt_resume_ptr__3_0 } {
         unsafe { (resume_fn)() };
@@ -72,7 +72,7 @@ pub fn resume() {
 ///
 /// Detach behaves similarly to [pause#example].
 ///
-/// [Collection Control API]: https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/collection-control-api.html
+/// [Collection Control API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/collection-control-api.html
 pub fn detach() {
     if let Some(detach_fn) = unsafe { ittapi_sys::__itt_detach_ptr__3_0 } {
         unsafe { (detach_fn)() };

--- a/rust/ittapi/src/domain.rs
+++ b/rust/ittapi/src/domain.rs
@@ -5,7 +5,7 @@ use std::ffi::CString;
 /// [Domain API] documentation for more information.
 ///
 /// [Domain API]:
-///     https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/domain-api.html
+///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/domain-api.html
 pub struct Domain(*mut ittapi_sys::__itt_domain);
 impl Domain {
     /// Create a new domain. Note that, if the `ittnotify` library is not initialized, this call
@@ -41,7 +41,7 @@ impl Domain {
 /// thread in the process.
 ///
 /// [ITT documentation]:
-///     https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/domain-api.html
+///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/domain-api.html
 unsafe impl Sync for Domain {}
 
 #[cfg(test)]

--- a/rust/ittapi/src/event.rs
+++ b/rust/ittapi/src/event.rs
@@ -2,7 +2,7 @@ use std::{ffi::CString, marker::PhantomData};
 
 /// See the [Event API] documentation.
 ///
-/// [Event API]: https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/event-api.html
+/// [Event API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/event-api.html
 ///
 /// ```
 /// let event = ittapi::Event::new("foo");

--- a/rust/ittapi/src/jit.rs
+++ b/rust/ittapi/src/jit.rs
@@ -3,7 +3,7 @@
 //! is a high-level view of a subset of the full functionality available. See the [JIT Profiling
 //! API] for more information.
 //!
-//! [JIT Profiling API]: https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/jit-profiling-api.html
+//! [JIT Profiling API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/jit-profiling-api.html
 use anyhow::Context;
 use std::{ffi::CString, os, ptr};
 

--- a/rust/ittapi/src/string.rs
+++ b/rust/ittapi/src/string.rs
@@ -5,7 +5,7 @@ use std::ffi::CString;
 /// documentation for more information.
 ///
 /// [String Handle API]:
-///     https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/string-handle-api.html
+///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/string-handle-api.html
 #[derive(PartialEq, Eq, Debug)]
 pub struct StringHandle(*mut ittapi_sys::__itt_string_handle);
 impl StringHandle {

--- a/rust/ittapi/src/task.rs
+++ b/rust/ittapi/src/task.rs
@@ -3,7 +3,7 @@ use crate::{domain::Domain, string::StringHandle};
 /// A task is a logical unit of work performed by a particular thread. See the [Task API]
 /// documentation for more information.
 ///
-/// [Task API]: https://www.intel.com/content/www/us/en/develop/documentation/vtune-help/top/api-support/instrumentation-and-tracing-technology-apis/instrumentation-tracing-technology-api-reference/task-api.html
+/// [Task API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/task-api.html
 ///
 /// ```
 /// # use ittapi::{Domain, StringHandle, Task};


### PR DESCRIPTION
This tweaks the links printed in the Rust documentation to point to the latest version of the API, v2024.1.