### PR TITLE
rust: use evergreen URL for doc links

### DIFF
--- a/rust/integration-tests/README.md
+++ b/rust/integration-tests/README.md
@@ -17,5 +17,5 @@ To install VTune, see the [User Guide]. The environment setup script (e.g., `vtu
 found within the VTune installation; e.g., `$HOME/intel/oneapi/vtune/latest` or
 `/opt/intel/oneapi/vtune/latest` on [Linux].
 
-[User Guide]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/installation.html
-[Linux]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/get-started-guide/2024-1/linux-os.html
+[User Guide]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/installation.html
+[Linux]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/get-started-guide/current/linux-os.html

--- a/rust/integration-tests/tests/main.rs
+++ b/rust/integration-tests/tests/main.rs
@@ -41,7 +41,7 @@ fn run_with_collector() {
 
     // Finally, check that the created report actually contains the measured tasks. It may be
     // interesting to filter by task here: e.g.,
-    // https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/filtering-and-grouping-reports.html
+    // https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/filtering-and-grouping-reports.html
     let report_stdout = run(&["vtune", "-report", "summary", result_dir_flag]);
     assert!(report_stdout.contains("task#1 "));
     assert!(report_stdout.contains("task#2 "));

--- a/rust/ittapi/src/collection_control.rs
+++ b/rust/ittapi/src/collection_control.rs
@@ -37,7 +37,7 @@
 /// // Do finalization work here
 /// ```
 ///
-/// [Collection Control API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/collection-control-api.html
+/// [Collection Control API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/collection-control-api.html
 pub fn pause() {
     if let Some(pause_fn) = unsafe { ittapi_sys::__itt_pause_ptr__3_0 } {
         unsafe { (pause_fn)() };
@@ -54,7 +54,7 @@ pub fn pause() {
 ///
 /// See [pause#example].
 ///
-/// [Collection Control API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/collection-control-api.html
+/// [Collection Control API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/collection-control-api.html
 pub fn resume() {
     if let Some(resume_fn) = unsafe { ittapi_sys::__itt_resume_ptr__3_0 } {
         unsafe { (resume_fn)() };
@@ -72,7 +72,7 @@ pub fn resume() {
 ///
 /// Detach behaves similarly to [pause#example].
 ///
-/// [Collection Control API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/collection-control-api.html
+/// [Collection Control API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/collection-control-api.html
 pub fn detach() {
     if let Some(detach_fn) = unsafe { ittapi_sys::__itt_detach_ptr__3_0 } {
         unsafe { (detach_fn)() };

--- a/rust/ittapi/src/domain.rs
+++ b/rust/ittapi/src/domain.rs
@@ -5,7 +5,7 @@ use std::ffi::CString;
 /// [Domain API] documentation for more information.
 ///
 /// [Domain API]:
-///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/domain-api.html
+///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/domain-api.html
 pub struct Domain(*mut ittapi_sys::__itt_domain);
 impl Domain {
     /// Create a new domain. Note that, if the `ittnotify` library is not initialized, this call
@@ -41,7 +41,7 @@ impl Domain {
 /// thread in the process.
 ///
 /// [ITT documentation]:
-///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/domain-api.html
+///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/domain-api.html
 unsafe impl Sync for Domain {}
 
 #[cfg(test)]

--- a/rust/ittapi/src/event.rs
+++ b/rust/ittapi/src/event.rs
@@ -2,7 +2,7 @@ use std::{ffi::CString, marker::PhantomData};
 
 /// See the [Event API] documentation.
 ///
-/// [Event API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/event-api.html
+/// [Event API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/event-api.html
 ///
 /// ```
 /// let event = ittapi::Event::new("foo");

--- a/rust/ittapi/src/jit.rs
+++ b/rust/ittapi/src/jit.rs
@@ -3,7 +3,7 @@
 //! is a high-level view of a subset of the full functionality available. See the [JIT Profiling
 //! API] for more information.
 //!
-//! [JIT Profiling API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/jit-profiling-api.html
+//! [JIT Profiling API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/jit-profiling-api.html
 use anyhow::Context;
 use std::{ffi::CString, os, ptr};
 

--- a/rust/ittapi/src/region.rs
+++ b/rust/ittapi/src/region.rs
@@ -34,7 +34,7 @@ impl Region {
     /// used for fine-grained profiling, such as [anomaly detection] (a preview feature of VTune).
     ///
     /// [anomaly detection]:
-    ///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/anomaly-detection-analysis.html
+    ///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/anomaly-detection-analysis.html
     ///
     /// ```
     /// # use ittapi::Region;

--- a/rust/ittapi/src/string.rs
+++ b/rust/ittapi/src/string.rs
@@ -5,7 +5,7 @@ use std::ffi::CString;
 /// documentation for more information.
 ///
 /// [String Handle API]:
-///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/string-handle-api.html
+///     https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/string-handle-api.html
 #[derive(PartialEq, Eq, Debug)]
 pub struct StringHandle(*mut ittapi_sys::__itt_string_handle);
 impl StringHandle {

--- a/rust/ittapi/src/task.rs
+++ b/rust/ittapi/src/task.rs
@@ -3,7 +3,7 @@ use crate::{domain::Domain, string::StringHandle};
 /// A task is a logical unit of work performed by a particular thread. See the [Task API]
 /// documentation for more information.
 ///
-/// [Task API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/2024-1/task-api.html
+/// [Task API]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/task-api.html
 ///
 /// ```
 /// # use ittapi::{Domain, StringHandle, Task};


### PR DESCRIPTION
As @Andy51 recommended in #147, this switches the VTune documentation links in the Rust doc comments to use
`...vtune-profiler/user-guide/current/...` instead of a more specific version. Ideally this will keep those links live for longer without requiring us to remember to update them.