### PR TITLE
Update header copyright info for advisor related files

### DIFF
--- a/include/AdvisorAnnotate.cs
+++ b/include/AdvisorAnnotate.cs
@@ -1,13 +1,5 @@
-// SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF END-USER LICENSE AGREEMENT
-// FOR INTEL(R) ADVISOR XE 2018.
-//
-// Copyright (c) 2012-2017 Intel Corporation. All rights reserved.
-//
-// THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL
-// PROPERTY RIGHTS.
-//
+// Copyright (C) 2012-2017 Intel Corporation
+// SPDX-License-Identifier: GPL-2.0-only OR BSD-3-Clause
 
 // This file defines functions used by the Intel(R) Advisor XE
 // "Dependencies Modeling" and "Suitability Modeling" analysis, which

--- a/include/fortran/advisor_annotate.f90
+++ b/include/fortran/advisor_annotate.f90
@@ -1,17 +1,7 @@
 ! ========================================================================
-!
-! SAMPLE SOURCE CODE - SUBJECT TO THE TERMS OF END-USER LICENSE AGREEMENT
-! FOR INTEL(R) ADVISOR XE 2018.
-!
-! Copyright (c) 2012-2017 Intel Corporation. All rights reserved.
-!
-! THIS FILE IS PROVIDED "AS IS" WITH NO WARRANTIES, EXPRESS OR IMPLIED,
-! INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTY OF MERCHANTABILITY,
-! FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT OF INTELLECTUAL
-! PROPERTY RIGHTS.
-!
+! Copyright (C) 2012-2017 Intel Corporation
+! SPDX-License-Identifier: GPL-2.0-only OR BSD-3-Clause
 ! ========================================================================
-!
 
 !--------
 !

--- a/include/fortran/posix/ittnotify.f90
+++ b/include/fortran/posix/ittnotify.f90
@@ -1,63 +1,7 @@
 ! ========================================================================
-! <copyright>
-!  This file is provided under a dual BSD/GPLv2 license.  When using or
-!  redistributing this file, you may do so under either license.
-!
-!  GPL LICENSE SUMMARY
-!
-!  Copyright (c) 2005-2017 Intel Corporation. All rights reserved.
-!
-!  This program is free software; you can redistribute it and/or modify
-!  it under the terms of version 2 of the GNU General Public License as
-!  published by the Free Software Foundation.
-!
-!  This program is distributed in the hope that it will be useful, but
-!  WITHOUT ANY WARRANTY; without even the implied warranty of
-!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-!  General Public License for more details.
-!
-!  You should have received a copy of the GNU General Public License
-!  along with this program; if not, write to the Free Software
-!  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
-!  The full GNU General Public License is included in this distribution
-!  in the file called LICENSE.GPL.
-!
-!  Contact Information:
-!  http://software.intel.com/en-us/articles/intel-vtune-amplifier-xe/
-!
-!  BSD LICENSE
-!
-!  Copyright (c) 2005-2017 Intel Corporation. All rights reserved.
-!  All rights reserved.
-!
-!  Redistribution and use in source and binary forms, with or without
-!  modification, are permitted provided that the following conditions
-!  are met:
-!
-!    * Redistributions of source code must retain the above copyright
-!      notice, this list of conditions and the following disclaimer.
-!    * Redistributions in binary form must reproduce the above copyright
-!      notice, this list of conditions and the following disclaimer in
-!      the documentation and/or other materials provided with the
-!      distribution.
-!    * Neither the name of Intel Corporation nor the names of its
-!      contributors may be used to endorse or promote products derived
-!      from this software without specific prior written permission.
-!
-!  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-!  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-!  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-!  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-!  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-!  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-!  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-!  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-!  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-!  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-!  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-! </copyright>
+! Copyright (C) 2005-2017 Intel Corporation
+! SPDX-License-Identifier: GPL-2.0-only OR BSD-3-Clause
 ! ========================================================================
-!
 
 !--------
 !

--- a/include/fortran/win32/ittnotify.f90
+++ b/include/fortran/win32/ittnotify.f90
@@ -1,63 +1,7 @@
 ! ========================================================================
-! <copyright>
-!  This file is provided under a dual BSD/GPLv2 license.  When using or
-!  redistributing this file, you may do so under either license.
-!
-!  GPL LICENSE SUMMARY
-!
-!  Copyright (c) 2005-2017 Intel Corporation. All rights reserved.
-!
-!  This program is free software; you can redistribute it and/or modify
-!  it under the terms of version 2 of the GNU General Public License as
-!  published by the Free Software Foundation.
-!
-!  This program is distributed in the hope that it will be useful, but
-!  WITHOUT ANY WARRANTY; without even the implied warranty of
-!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-!  General Public License for more details.
-!
-!  You should have received a copy of the GNU General Public License
-!  along with this program; if not, write to the Free Software
-!  Foundation, Inc., 51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
-!  The full GNU General Public License is included in this distribution
-!  in the file called LICENSE.GPL.
-!
-!  Contact Information:
-!  http://software.intel.com/en-us/articles/intel-vtune-amplifier-xe/
-!
-!  BSD LICENSE
-!
-!  Copyright (c) 2005-2017 Intel Corporation. All rights reserved.
-!  All rights reserved.
-!
-!  Redistribution and use in source and binary forms, with or without
-!  modification, are permitted provided that the following conditions
-!  are met:
-!
-!    * Redistributions of source code must retain the above copyright
-!      notice, this list of conditions and the following disclaimer.
-!    * Redistributions in binary form must reproduce the above copyright
-!      notice, this list of conditions and the following disclaimer in
-!      the documentation and/or other materials provided with the
-!      distribution.
-!    * Neither the name of Intel Corporation nor the names of its
-!      contributors may be used to endorse or promote products derived
-!      from this software without specific prior written permission.
-!
-!  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-!  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-!  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-!  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-!  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-!  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-!  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-!  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-!  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-!  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-!  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-! </copyright>
+! Copyright (C) 2005-2017 Intel Corporation
+! SPDX-License-Identifier: GPL-2.0-only OR BSD-3-Clause
 ! ========================================================================
-!
 
 !--------
 !


### PR DESCRIPTION
It seems that we just forgot to change the header copyright in these files after we added them to this repository.
Fix for the related issue https://github.com/intel/ittapi/issues/149