### PR TITLE
ci: add release workflow to include ittapi wheels in release package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,37 +43,33 @@ jobs:
           build*/**/bin
           build*/**/fortran
 
+  # build wheels only for cpython versions 3.8-3.12 on linux and windows 64-bits
   python_build:
-    name: Build python ittapi package
+    name: Build ittapi wheels
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            cibw_skip_args: "*_i686 *-musllinux_* cp313-*"
+          - os: windows-latest
+            cibw_skip_args: "*-win32 *_i686 cp313-*"
     steps:
-      - name: checkout sources
+      - name: Checkout sources
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install cibuildwheels
         run: python -m pip install cibuildwheel==2.20.0
-      - name: Build ittapi python wheels for Linux
-        if: runner.os != 'Windows'
-        run: python -m cibuildwheel python --output-dir python_build/ittapi_python_linux
-        # building for python 3.8-3.12 on linux for x86
+      - name: Build ittapi python wheels
+        run: python -m cibuildwheel python --output-dir python_dist/${{ runner.os }}
         env:
           CIBW_BUILD: cp3*
-          CIBW_SKIP: "*_i686 *-musllinux_* cp313-*"
-      - name: Build ittapi python wheels for Windows
-        if: runner.os == 'Windows'
-        run: python -m cibuildwheel python --output-dir python_build/ittapi_python_windows
-        # building for python 3.8-3.12 on windows for x86 and 64bit
-        env:
-          CIBW_BUILD: cp3*
-          CIBW_SKIP: "*-win32 *_i686 cp313-*"
-
-      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+          CIBW_SKIP: ${{ matrix.cibw_skip_args }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
         with:
           name: build-artifacts-python-${{ matrix.os }}
-          path: ./python_build/
+          path: python_dist*/**
 
   create_release:
     permissions:
@@ -106,7 +102,7 @@ jobs:
         run: |
             zip -r ittapi_build_${{ github.ref_name }}.zip include &&
             cd build-artifacts &&
-            zip -rg ../ittapi_build_${{ github.ref_name }}.zip build*/**/bin build*/**/fortran ittapi_python* &&
+            zip -rg ../ittapi_build_${{ github.ref_name }}.zip build*/**/bin build*/**/fortran python_dist &&
             cd -
       - name: Upload release asset
         id: upload-release-asset 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,44 @@ jobs:
           build*/**/bin
           build*/**/fortran
 
+  python_build:
+    name: Build python ittapi package
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - name: checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Install cibuildwheels
+        run: python -m pip install cibuildwheel==2.20.0
+      - name: Build ittapi python wheels for Linux
+        if: runner.os != 'Windows'
+        run: python -m cibuildwheel python --output-dir python_build/ittapi_python_linux
+        # building for python 3.8-3.12 on linux for x86
+        env:
+          CIBW_BUILD: cp3*
+          CIBW_SKIP: "*_i686 *-musllinux_* cp313-*"
+      - name: Build ittapi python wheels for Windows
+        if: runner.os == 'Windows'
+        run: python -m cibuildwheel python --output-dir python_build/ittapi_python_windows
+        # building for python 3.8-3.12 on windows for x86 and 64bit
+        env:
+          CIBW_BUILD: cp3*
+          CIBW_SKIP: "*-win32 *_i686 cp313-*"
+
+      - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+          name: build-artifacts-python-${{ matrix.os }}
+          path: ./python_build/
+
   create_release:
     permissions:
       contents: write  # for actions/create-release to create a release
     name: Create release
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, python_build]
     steps:
       - name: Checkout sources
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -74,7 +106,7 @@ jobs:
         run: |
             zip -r ittapi_build_${{ github.ref_name }}.zip include &&
             cd build-artifacts &&
-            zip -rg ../ittapi_build_${{ github.ref_name }}.zip build*/**/bin build*/**/fortran &&
+            zip -rg ../ittapi_build_${{ github.ref_name }}.zip build*/**/bin build*/**/fortran ittapi_python* &&
             cd -
       - name: Upload release asset
         id: upload-release-asset 


### PR DESCRIPTION
Added release workflow to add ittapi python wheels in to ittapi release package.

Added wheels for the following configurations:
- CPython versions 3.8-3.12
- Linux/Windows 64-bits