### PR TITLE
doc: add contributing guide and badges bar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to Intel® Instrumentation and Tracing Technology (ITT) and Just-In-Time (JIT) API
+
+We welcome contributions from everyone. Your efforts help improve the project and are greatly appreciated.
+
+## Contribution Process
+
+- **Fork** the repository
+- **Make Changes**: 
+  - Clone your fork
+  - Create a new branch
+  - Implement your changes and commit with a clear message
+- **Pull Request**: 
+  - Push to your fork
+  - Open a pull request to merge your branch into the main repository with a clear title and description
+
+## Review
+
+- Maintainers will review your pull request
+- You may be asked to make changes
+- Approved changes will be merged
+
+## Licensing
+
+- All code is dual licensed under GPLv2 and 3-Clause BSD
+- All contributions must carry these licenses
+
+Thank you for contributing to Intel® Instrumentation and Tracing Technology (ITT) and Just-In-Time (JIT) API

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Intel® Instrumentation and Tracing Technology (ITT) and Just-In-Time (JIT) API
 [![CodeQL](https://github.com/intel/ittapi/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/intel/ittapi/security/code-scanning/tools/CodeQL/status)
 [![Package on conda-forge](https://img.shields.io/conda/vn/conda-forge/ittapi.svg)](https://anaconda.org/conda-forge/ittapi)
 [![Package on PyPI](https://img.shields.io/pypi/v/ittapi)](https://pypi.org/project/ittapi)
+[![Package on crates.io](https://img.shields.io/crates/v/ittapi.svg)](https://crates.io/crates/ittapi)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/intel/ittapi/badge)](https://securityscorecards.dev/viewer/?uri=github.com/intel/ittapi)
 
 This ITT/JIT open source profiling API includes:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ All code in the repo is dual licensed under GPLv2 and 3-Clause BSD licenses
 
 ### Contributing
 
-To contribute, please see our [contributing guide](CONTRIBUTING.md)
+To contribute, please see our [contributing guide](CONTRIBUTING.md)  
+To report bugs or request enhancements, please use the "Issues" page on GitHub
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ optional arguments:
 
 All code in the repo is dual licensed under GPLv2 and 3-Clause BSD licenses
 
+### Contributing
+
+To contribute, please see our [contributing guide](CONTRIBUTING.md)
+
 ### Security
 
 Please refer to the [security policy](SECURITY.md) for reporting vulnerabilties.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 Intel® Instrumentation and Tracing Technology (ITT) and Just-In-Time (JIT) API
 ==================================================================================
 
+[![Build Status](https://github.com/intel/ittapi/actions/workflows/main.yml/badge.svg?branch=master&event=push)](https://github.com/intel/ittapi/actions)
+[![CodeQL](https://github.com/intel/ittapi/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/intel/ittapi/security/code-scanning/tools/CodeQL/status)
+[![Package on conda-forge](https://img.shields.io/conda/vn/conda-forge/ittapi.svg)](https://anaconda.org/conda-forge/ittapi)
+[![Package on PyPI](https://img.shields.io/pypi/v/ittapi)](https://pypi.org/project/ittapi)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/intel/ittapi/badge)](https://securityscorecards.dev/viewer/?uri=github.com/intel/ittapi)
+
 This ITT/JIT open source profiling API includes:
 
   - Instrumentation and Tracing Technology (ITT) API


### PR DESCRIPTION
Small improvements for our documentations:
- Add contributing guide to involve new contributors
- Update README file:
  - Add contributing section to README file
  - Add CI/CodeQL/OpenSSF scorecard badges to demonstrate product health status
  - Add conda-forge/PyPI/crates.io badges to help users to easier get the latest product version

Badges bar:
![image](https://github.com/user-attachments/assets/e08ca0d0-89da-4878-a984-e5d3734d0b81)