### PR TITLE
ci: run `rust-clippy`, send results to CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,9 +96,9 @@ jobs:
 
       - name: Run clippy
         run: |
-          touch clippy.sarif
           cargo clippy --message-format=json > clippy.json
-          cat clippy.json
+          clippy-sarif --input clippy.json --output clippy.sarif
+          sarif-fmt --input clippy.sarif
         continue-on-error: true
 
       - name: Upload analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run clippy
         run: |
-          cargo clippy --message-format=json > clippy.json
+          cargo clippy --all-features --message-format=json > clippy.json
           clippy-sarif --input clippy.json --output clippy.sarif
           sarif-fmt --input clippy.sarif
         continue-on-error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,9 +96,7 @@ jobs:
 
       - name: Run clippy
         run: |
-          cargo --version
-          cargo clippy --version
-          cargo clippy --all-features --message-format=json > clippy.json
+          cargo clippy --message-format=json > clippy.json
           clippy-sarif --input clippy.json --output clippy.sarif
           sarif-fmt --input clippy.sarif
         continue-on-error: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,9 +96,8 @@ jobs:
 
       - name: Run clippy
         run: |
-          cargo clippy --message-format=json > clippy.json
-          clippy-sarif --input clippy.json --output clippy.sarif
-          sarif-fmt --input clippy.sarif
+          cargo clippy --message-format=json
+          touch clippy.sarif
         continue-on-error: true
 
       - name: Upload analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,13 +88,10 @@ jobs:
       - name: Install dependencies
         run: |
           rustup component add clippy
-          cargo install clippy-sarif sarif-fmt
+          cargo binstall clippy-sarif sarif-fmt
 
       - name: Run clippy
-        run:
-          cargo clippy
-          --all-features
-          --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+        run: cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true
 
       - name: Upload analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Run clippy
         run: |
-	  cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+          cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true
 
       - name: Upload analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install dependencies
         run: |
           rustup component add clippy
-          cargo binstall clippy-sarif sarif-fmt
+          cargo install clippy-sarif sarif-fmt
 
       - name: Run clippy
         run: cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -92,7 +92,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@v1.10.6
 
       - name: Install dependencies
-        run: cargo binstall clippy-sarif sarif-fmt
+        run: cargo binstall --no-confirm clippy-sarif sarif-fmt
 
       - name: Run clippy
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,12 +96,13 @@ jobs:
 
       - name: Run clippy
         run: |
-          cargo clippy --message-format=json
           touch clippy.sarif
+          cargo clippy --message-format=json > clippy.json
+          cat clippy.json
         continue-on-error: true
 
       - name: Upload analysis
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: clippy.sarif
+          sarif_file: rust/clippy.sarif
           wait-for-processing: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,3 +71,34 @@ jobs:
         uses: github/codeql-action/analyze@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
         with:
           category: "/language:${{matrix.language}}"
+
+  analyze_rust:
+    name: Analyze (Rust)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install dependencies
+        run: |
+          rustup component add clippy
+          cargo install clippy-sarif sarif-fmt
+
+      - name: Run clippy
+        run:
+          cargo clippy
+          --all-features
+          --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+        continue-on-error: true
+
+      - name: Upload analysis
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: rust-clippy-results.sarif
+          wait-for-processing: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,13 +85,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: Install clippy
+        run: rustup component add clippy
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.10.6
+
       - name: Install dependencies
-        run: |
-          rustup component add clippy
-          cargo install clippy-sarif sarif-fmt
+        run: cargo binstall clippy-sarif sarif-fmt
 
       - name: Run clippy
-        run: cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+        run: |
+	  cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
         continue-on-error: true
 
       - name: Upload analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,11 +96,13 @@ jobs:
 
       - name: Run clippy
         run: |
-          cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+          cargo clippy --all-features --message-format=json > clippy.json
+          clippy-sarif --input clippy.json --output clippy.sarif
+          sarif-fmt --input clippy.sarif
         continue-on-error: true
 
       - name: Upload analysis
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: rust-clippy-results.sarif
+          sarif_file: clippy.sarif
           wait-for-processing: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -96,6 +96,8 @@ jobs:
 
       - name: Run clippy
         run: |
+          cargo --version
+          cargo clippy --version
           cargo clippy --all-features --message-format=json > clippy.json
           clippy-sarif --input clippy.json --output clippy.sarif
           sarif-fmt --input clippy.sarif


### PR DESCRIPTION
This adds a new analysis job to run Rust's code quality analyzer, `rust-clippy`, and upload the JSON results to GitHub's CodeQL service. This template was suggested by GitHub itself and I've modified it to fit our repository; let's see how this goes.