### PR TITLE
ci: fix clippy's CodeQL messages

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,7 +97,9 @@ jobs:
       - name: Run clippy
         run: |
           cargo clippy --all-features --message-format=json > clippy.json
+          sed --in-place 's/"file_name":"itt/"file_name":"rust\/itt/g' clippy.json
           clippy-sarif --input clippy.json --output clippy.sarif
+          cd ..
           sarif-fmt --input clippy.sarif
         continue-on-error: true
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,9 +75,6 @@ jobs:
   analyze_rust:
     name: Analyze (Rust)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: rust
     permissions:
       contents: read
       security-events: write
@@ -95,13 +92,15 @@ jobs:
         run: cargo binstall --no-confirm clippy-sarif sarif-fmt
 
       - name: Run clippy
+        working-directory: rust
         run: |
           cargo clippy --all-features --message-format=json > clippy.json
           sed --in-place 's/"file_name":"itt/"file_name":"rust\/itt/g' clippy.json
           clippy-sarif --input clippy.json --output clippy.sarif
-          cd ..
-          sarif-fmt --input clippy.sarif
         continue-on-error: true
+
+      - name: Print SARIF
+        run: sarif-fmt --input rust/clippy.sarif
 
       - name: Upload analysis
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Looking at the first Rust code scan issue ([#1]), it looks like it can't show the preview because of a directory issue. Because the Rust crates are in a sub-directory, `rust`, to get proper previews we need to prepend that directory, accomplished here by a simple `sed` replacement.

[#1]: https://github.com/intel/ittapi/security/code-scanning/1