### PR TITLE
Minor changes to pin GitHub Action versions and align text with trademark rules

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,23 +1,12 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
-    branches: ["master"]
+    branches: [ master, ghactions]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ["master"]
+    branches: [ master ]
   schedule:
+    # Run every Monday at midnight
     - cron: "0 0 * * 1"
 
 permissions:
@@ -36,39 +25,21 @@ jobs:
       fail-fast: false
       matrix:
         language: ["cpp", "python"]
-        # CodeQL supports [ $supported-codeql-languages ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
+        uses: github/codeql-action/init@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
           languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
+        uses: github/codeql-action/autobuild@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e8893c57a1f3a2b659b6b55564fdfdbbd2982911 # v3.24.0
+        uses: github/codeql-action/analyze@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
           category: "/language:${{matrix.language}}"
 
@@ -86,7 +57,7 @@ jobs:
         run: rustup component add clippy
 
       - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@v1.10.6
+        uses: cargo-bins/cargo-binstall@c175bb02c4d5486f22e1a9cb4186cb6097f01434 # 1.10.23
 
       - name: Install dependencies
         run: cargo binstall --no-confirm clippy-sarif sarif-fmt
@@ -103,7 +74,7 @@ jobs:
         run: sarif-fmt --input rust/clippy.sarif
 
       - name: Upload analysis
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.9
         with:
           sarif_file: rust/clippy.sarif
           wait-for-processing: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,10 @@
-name: CodeQL
+name: "CodeQL"
 
 on:
   push:
-    branches: [ master, ghactions]
+    branches: ["master"]
   pull_request:
-    branches: [ master ]
+    branches: ["master"]
   schedule:
     # Run every Monday at midnight
     - cron: "0 0 * * 1"

--- a/src/ittnotify/ittnotify_static.c
+++ b/src/ittnotify/ittnotify_static.c
@@ -1672,7 +1672,7 @@ ITT_EXTERN_C __itt_collection_state (_N_(get_collection_state))(void)
 
 /* !!! should be called from the library destructor !!!
  * this function destroys the mutex and frees resources
- * allocated by ITT API static part
+ * allocated by static library
  */
 ITT_EXTERN_C void (_N_(release_resources))(void)
 {

--- a/src/ittnotify_refcol/README.md
+++ b/src/ittnotify_refcol/README.md
@@ -1,3 +1,5 @@
+# Instrumentation and Tracing Technology API (ITT API) Reference Collector
+
 This is a reference implementation of the ITT API _dynamic part_
 that performs tracing data from ITT API functions calls to log files.
 

--- a/src/ittnotify_refcol/itt_refcol_impl.c
+++ b/src/ittnotify_refcol/itt_refcol_impl.c
@@ -136,7 +136,8 @@ void log_func_call(uint8_t log_level, const char* function_name, const char* mes
 #define LOG_FUNC_CALL_FATAL(...) log_func_call(LOG_LVL_FATAL, __FUNCTION__, __VA_ARGS__)
 
 /* ------------------------------------------------------------------------------ */
-/* The code below is a reference implementation of the ITT API dynamic collector. */
+/* The code below is a reference implementation of the
+/* Instrumentation and Tracing Technology API (ITT API) dynamic collector.
 /* This implementation is designed to log ITTAPI functions calls.*/
 /* ------------------------------------------------------------------------------ */
 


### PR DESCRIPTION
This PR includes the following minor changes:

- Updated the CodeQL GitHub Actions to pin specific versions by hash as required by security rules and deleted not needed autogenerated comments from the workflow file.
- Updated comments and documentation to use the full name "Instrumentation and Tracing Technology API (ITT API)" on the first mention, in accordance with Intel trademark rules.