### PR TITLE
add formatted metadata support

### DIFF
--- a/include/ittnotify.h
+++ b/include/ittnotify.h
@@ -2454,8 +2454,58 @@ typedef enum {
     __itt_metadata_u16,     /**< Unsigned 16-bit integer */
     __itt_metadata_s16,     /**< Signed 16-bit integer */
     __itt_metadata_float,   /**< Signed 32-bit floating-point */
-    __itt_metadata_double   /**< SIgned 64-bit floating-point */
+    __itt_metadata_double,  /**< Signed 64-bit floating-point */
+    __itt_metadata_string   /**< String*/
 } __itt_metadata_type;
+
+/**
+ * @ingroup parameters
+ * @brief Add metadata to an instance of a named entity.
+ * @param[in] domain The domain controlling the call
+ * @param[in] format The format of the metadata
+ * @param[in] ... The metadata itself as multiple arguments
+ */
+void ITTAPI __itt_formatted_metadata_add(const __itt_domain *domain, __itt_string_handle *format, ...);
+
+/** @cond exclude_from_documentation */
+#ifndef INTEL_NO_MACRO_BODY
+#ifndef INTEL_NO_ITTNOTIFY_API
+ITT_STUBV(ITTAPI, void, formatted_metadata_add, (const __itt_domain *domain, __itt_string_handle *format, ...))
+#define __itt_formatted_metadata_add     ITTNOTIFY_VOID(formatted_metadata_add)
+#define __itt_formatted_metadata_add_ptr ITTNOTIFY_NAME(formatted_metadata_add)
+#else  /* INTEL_NO_ITTNOTIFY_API */
+#define __itt_formatted_metadata_add(domain, format, metadata)
+#define __itt_formatted_metadata_add_ptr 0
+#endif /* INTEL_NO_ITTNOTIFY_API */
+#else  /* INTEL_NO_MACRO_BODY */
+#define __itt_formatted_metadata_add_ptr 0
+#endif /* INTEL_NO_MACRO_BODY */
+/** @endcond */
+
+/**
+ * @ingroup parameters
+ * @brief Add metadata to an instance of a named entity.
+ * @param[in] domain The domain controlling the call
+ * @param[in] taskid The identifier for this task instance, *cannot* be __itt_null.
+ * @param[in] format The format of the metadata
+ * @param[in] ... The metadata itself as multiple arguments
+ */
+void ITTAPI __itt_formatted_metadata_add_overlapped(const __itt_domain *domain, __itt_id taskid, __itt_string_handle *format, ...);
+
+/** @cond exclude_from_documentation */
+#ifndef INTEL_NO_MACRO_BODY
+#ifndef INTEL_NO_ITTNOTIFY_API
+ITT_STUBV(ITTAPI, void, formatted_metadata_add_overlapped, (const __itt_domain *domain, __itt_id taskid, __itt_string_handle *format, ...))
+#define __itt_formatted_metadata_add_overlapped     ITTNOTIFY_VOID(formatted_metadata_add_overlapped)
+#define __itt_formatted_metadata_add_ptr_overlapped ITTNOTIFY_NAME(formatted_metadata_add_overlapped)
+#else  /* INTEL_NO_ITTNOTIFY_API */
+#define __itt_formatted_metadata_add_overlapped(domain, taskid, format, metadata)
+#define __itt_formatted_metadata_add_ptr_overlapped 0
+#endif /* INTEL_NO_ITTNOTIFY_API */
+#else  /* INTEL_NO_MACRO_BODY */
+#define __itt_formatted_metadata_add_ptr_overlapped 0
+#endif /* INTEL_NO_MACRO_BODY */
+/** @endcond */
 
 /**
  * @ingroup parameters

--- a/src/ittnotify/ittnotify_static.h
+++ b/src/ittnotify/ittnotify_static.h
@@ -207,6 +207,12 @@ ITT_STUBV(ITTAPI, void, counter_dec_delta_v3, (const __itt_domain *domain, __itt
 
 ITT_STUBV(ITTAPI, void, marker, (const __itt_domain *domain, __itt_id id, __itt_string_handle *name, __itt_scope scope), (ITT_FORMAT domain, id, name, scope), marker, __itt_group_structure, "%p, %lu, %p, %d")
 
+ITT_STUBV(ITTAPI, void, formatted_metadata_add, (const __itt_domain *domain, __itt_string_handle *format, ...), \
+  (ITT_FORMAT domain, format), formatted_metadata_add, __itt_group_structure, "%p, %p")
+
+ITT_STUBV(ITTAPI, void, formatted_metadata_add_overlapped, (const __itt_domain *domain, __itt_id id, __itt_string_handle *format, ...), \
+  (ITT_FORMAT domain, id, format), formatted_metadata_add_overlapped, __itt_group_structure, "%p, %lu, %p")
+
 ITT_STUBV(ITTAPI, void, metadata_add,      (const __itt_domain *domain, __itt_id id, __itt_string_handle *key, __itt_metadata_type type, size_t count, void *data), (ITT_FORMAT domain, id, key, type, count, data), metadata_add, __itt_group_structure, "%p, %lu, %p, %d, %lu, %p")
 #if ITT_PLATFORM==ITT_PLATFORM_WIN
 ITT_STUBV(ITTAPI, void, metadata_str_addA, (const __itt_domain *domain, __itt_id id, __itt_string_handle *key, const char* data, size_t length),    (ITT_FORMAT domain, id, key, data, length), metadata_str_addA, __itt_group_structure, "%p, %lu, %p, %p, %lu")


### PR DESCRIPTION
With this we can add formatted metadata support for ITT task API.
At first we need to declare __itt_string_handle* format in a printf format style, for example "Running [%s] task iteration %llu". Format specifiers in square brackets create additional grouping options in VTune analysis views
Then we call function   __itt_formatted_metadata_add with arguments  (domain, format, arg1, arg2), where domain is associated __itt_domain, format is printf-style string, arg1 and arg2 are arguments for this specific format.
The new function should be called between __itt_task_begin and __itt_task_end calls.

Also there's a support for overlapped ITT tasks:
__itt_formatted_metadata_add_overlapped(const __itt_domain *domain, __itt_id taskid, __itt_string_handle *format, ...)
where we add taskid from the relevant overlapped ITT task.