### PR TITLE
src: ittnotify: ittnotify_static: resolve Wundef hits

### DIFF
--- a/src/ittnotify/ittnotify_static.c
+++ b/src/ittnotify/ittnotify_static.c
@@ -62,7 +62,7 @@ static const char api_version[] = API_VERSION "\0\n@(#) $Revision$\n";
 #define ITT_ATTRIBUTE_FALLTHROUGH [[gnu::fallthrough]]
 #elif HAS_CPP_ATTR(clang::fallthrough)
 #define ITT_ATTRIBUTE_FALLTHROUGH [[clang::fallthrough]]
-#elif HAS_GNU_ATTR(fallthrough) && !__INTEL_COMPILER
+#elif HAS_GNU_ATTR(fallthrough) && !defined(__INTEL_COMPILER)
 #define ITT_ATTRIBUTE_FALLTHROUGH __attribute__((fallthrough))
 #else
 #define ITT_ATTRIBUTE_FALLTHROUGH

--- a/src/ittnotify/ittnotify_static.c
+++ b/src/ittnotify/ittnotify_static.c
@@ -56,7 +56,7 @@ static const char api_version[] = API_VERSION "\0\n@(#) $Revision$\n";
 #endif
 
 #ifndef ITT_ATTRIBUTE_FALLTHROUGH
-#if (HAS_CPP_ATTR(fallthrough) || HAS_C_ATTR(fallthrough)) && (__cplusplus >= 201703L || _MSVC_LANG >= 201703L)
+#if (HAS_CPP_ATTR(fallthrough) || HAS_C_ATTR(fallthrough)) && ((defined(__cplusplus) && __cplusplus >= 201703L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
 #define ITT_ATTRIBUTE_FALLTHROUGH [[fallthrough]]
 #elif HAS_CPP_ATTR(gnu::fallthrough)
 #define ITT_ATTRIBUTE_FALLTHROUGH [[gnu::fallthrough]]


### PR DESCRIPTION
Some projects that include oneDNN use `-Wundef` compilation flag. oneDNN decided to add the flag into the build as well and it automatically promoted to third_party dependencies including ittnotify.

Macros that may not be defined must be checked for presence first.