### PR TITLE
ci: upgrade gh-action-pypi-publish release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
       - name: List wheel files
         run: find -name *.whl
       - name: Publish package distributions to PyPi
-        uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # v1.10.1
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           password: ${{ secrets.PYPI }}
           repository-url: https://upload.pypi.org/legacy/


### PR DESCRIPTION
Fix upload the python wheel files to pypi release job.
The last one attempt failed at: https://github.com/intel/ittapi/actions/runs/14841658021/job/41666423384