### PR TITLE
ci: restrict write permissions to job scope in deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,10 +8,12 @@ on:
       - 'docs/**' # Trigger only when the source docs files are modified
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build_and_deploy:
+    permissions:
+      contents: write  # for peaceiris/actions-gh-pages to push pages branch
     name: Build and deploy documentation
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
   create_release:
     permissions:
-      contents: write  # for actions/create-release to create a release
+      contents: write     # for actions/create-release to create a release
       id-token: write     # for actions/attest-build-provenance to attest provenance
       attestations: write # for actions/attest-build-provenance to attest provenance
     name: Create release

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This repository contains the source files for the ITT/JIT APIs online documentation,
-which is hosted on GitHub Pages. [View the documentation here](link).
+which is hosted on GitHub Pages. [View the documentation here](https://intel.github.io/ittapi).
 
 ## Build Documentation from Sources
 


### PR DESCRIPTION
Limit write permissions to the deploy job only, enhancing workflow security by removing unnecessary global write access.
https://github.com/ossf/scorecard/blob/1f95bf1a00b7a1344c5d75932032026b8891bfec/docs/checks.md#token-permissions

Fix broken link in docs README file