### PR TITLE
ci: fix 32-bit linux compilation by reverting setup-fortran gh action to v1.6.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Setup Fortran compiler
-      uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1.8.1
+      uses: fortran-lang/setup-fortran@8821f57b53846d35d62632eb51c60ac6c4bff4ce # v1.6.1
       with:
           compiler: intel
     - name: Build C library

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install gcc-multilib
     - name: Setup Fortran compiler
-      uses: fortran-lang/setup-fortran@47809fdb6e637da656ce9ada436527b240c1287f # v1.8.1
+      uses: fortran-lang/setup-fortran@8821f57b53846d35d62632eb51c60ac6c4bff4ce # v1.6.1
       with:
           compiler: intel
     - name: Build C library


### PR DESCRIPTION
Reverts intel/ittapi#213
The setup-fortran gh action installs intel compiler on the system.
Switch intel compiler back to version 2024.1 since 2025.0 version doesn't support 32-bit compilation with -m32 flag

Build error log:
```
-- Build files have been written to: /home/runner/work/ittapi/ittapi/build_linux/32
[ 16%] Building C object CMakeFiles/ittnotify.dir/src/ittnotify/ittnotify_static.c.o
icx: error: unsupported option '-m32'
icx: error: unsupported option '-m32'
gmake[2]: *** [CMakeFiles/ittnotify.dir/build.make:79: CMakeFiles/ittnotify.dir/src/ittnotify/ittnotify_static.c.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:90: CMakeFiles/ittnotify.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
>> failed to run shell command: cmake --build . --config Release
```