### PR TITLE
docs: clarify dual license wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ We welcome contributions from everyone. Your efforts help improve the project an
 
 ## Licensing
 
-- All code is dual licensed under GPLv2 and 3-Clause BSD
+- All code is dual-licensed under either the BSD-3-Clause or the GPL-2.0-only license
 - All contributions must carry these licenses
 
 Thank you for contributing to Intel® Instrumentation and Tracing Technology (ITT) and Just-In-Time (JIT) API

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Find complete documentation for ITT/JIT APIs on the
 
 ### License
 
-All code in the repo is dual licensed under GPLv2 and 3-Clause BSD licenses
+This project is dual-licensed under either the BSD-3-Clause or the GPL-2.0-only license
 
 ### Make Contributions
 


### PR DESCRIPTION
Reword the license section to make it explicit that users may choose either the BSD-3-Clause or the GPL-2.0-only license, matching the SPDX headers in source files.