### PR TITLE
ci: fix missing build artifacts in release package

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload CodeQL Security Report
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codeql-report-${{ matrix.language }}
           path: report.pdf
@@ -113,7 +113,7 @@ jobs:
         run: sarif html --output bandit-report.html results.sarif
 
       - name: Upload Bandit Scan report
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bandit-report
           path: bandit-report.html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Display structure of files
       run: ls -R
     - name: Upload artifact
-      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: build-artifacts-${{ matrix.os }}
         path: |
@@ -68,7 +68,7 @@ jobs:
           CIBW_BUILD: cp3*
           CIBW_SKIP: ${{ matrix.cibw_skip_args }}
       - name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-artifacts-python-${{ matrix.os }}
           path: python_dist*/**
@@ -95,7 +95,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Download artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: build-artifacts
           pattern: build-artifacts-*
@@ -106,7 +106,7 @@ jobs:
         run: |
             zip -r ittapi_build_${{ github.ref_name }}.zip include &&
             cd build-artifacts &&
-            zip -rg ../ittapi_build_${{ github.ref_name }}.zip build*/**/bin build*/**/fortran python_dist &&
+            zip -rg ../ittapi_build_${{ github.ref_name }}.zip build*/bin build*/fortran python_dist &&
             cd -
       - name: Generate release provenance
         uses: actions/attest-build-provenance@00014ed6ed5efc5b1ab7f7f34a39eb55d41aa4f8 # v3.1.0
@@ -130,7 +130,7 @@ jobs:
     needs: [python_build, create_release]
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: build-artifacts-*
           merge-multiple: true


### PR DESCRIPTION
After dropping 32-bit support, the build output structure changed from `build_linux/64/bin` to `build_linux/bin`. The zip command in the release workflow used a path pattern that no longer matched, resulting in release packages missing all platform build folders (linux, windows, darwin). Fixed the zip path to include build artifacts correctly.

+bumped artifacts download/upload actions versions